### PR TITLE
Update channel.html

### DIFF
--- a/articles/channel.html
+++ b/articles/channel.html
@@ -57,14 +57,14 @@ Concurrent computations may share resources, generally memory resource.
 There are some circumstances may happen in a concurrent computing.
 <ul>
 <li>
-	In the same period of one computation is writing data to a memroy segment,
-	another computation is reading data from the same memroy segment.
+	In the same period of one computation is writing data to a memory segment,
+	another computation is reading data from the same memory segment.
 	Then the integrity of the data read by the other computation might be not preserved.
 </li>
 <li>
-	In the same period of one computation is writing data to a memroy segment,
-	another computation is also writing data to the same memroy segment.
-	Then the integrity of the data stored at the memroy segment might be not preserved.
+	In the same period of one computation is writing data to a memory segment,
+	another computation is also writing data to the same memory segment.
+	Then the integrity of the data stored at the memory segment might be not preserved.
 </li>
 </ul>
 
@@ -121,7 +121,7 @@ Communicating by sharing memory and sharing memory by communicating
 are two patterns in concurrent programming.
 When goroutines communicate by sharing memory, we need use some
 tranditional concurrency synchronization techniques, such as mutex locks,
-to protect the shared memory to void data races.
+to protect the shared memory to prevent data races.
 </p>
 
 <p>
@@ -329,7 +329,7 @@ not synchronized, though channel any receive operation is synchronized.
 
 <p>
 If the queried channel is a nil channel, both of the
-built-in <codde>cap</code> and <code>len</code> functions return zero.
+built-in <code>cap</code> and <code>len</code> functions return zero.
 The two query operations are so simple that
 they will not get further explanations later.
 In fact, the two operations are seldom used in practice.


### PR DESCRIPTION
- Memory was spelled as "memroy" in several places and fixed
- "void" was replaced with "prevents" as "prevents" seems like a better fit
- Fixed HTML tag spelling <codde> to <code>