### PR TITLE
docs: fix typos

### DIFF
--- a/articles/basic-code-elements-introduction.html
+++ b/articles/basic-code-elements-introduction.html
@@ -175,7 +175,7 @@ Some other types (composite types) will be introduced later in other articles.
 </p>
 
 <p>
-Line <code>27</code> is an assignment.
+Line <i>27</i> is an assignment.
 Line <i>5</i> declares a named constant, <code>MaxRand</code>.
 Line <i>14</i> and line <i>27</i> declare three variables,
 with the standard variable declaration form.

--- a/articles/basic-code-elements-introduction.html
+++ b/articles/basic-code-elements-introduction.html
@@ -2,7 +2,7 @@
 
 <p>
 Go is known for its simple and clean syntax.
-This article will inctoduce the common source code elements in programming
+This article will introduce the common source code elements in programming
 and show a simple Go program so that
 new gophers (Go programmers) will get a basic impression of Go code structures
 and how all kinds of code elements are used in Go code.

--- a/articles/basic-code-elements-introduction.html
+++ b/articles/basic-code-elements-introduction.html
@@ -163,10 +163,10 @@ for more information keywords and identifiers.
 <p>
 The green <code>int</code> words at line <i>14</i> and line <i>16</i>
 denotes the buint-in <code>int</code> type, one of many kinds of integer types in Go.
-The <code>16</code> at line <i>5</i>, <code>0</code> at line <i>18</i>,
-<code>1</code> at line <i>23</i> and <code>100</code> at line <i>33</i>
+The <code>16</code> at line <i>5</i>, <code>0</code> at line <i>15</i>,
+<code>1</code> at line <i>17</i> and <code>100</code> at line <i>27</i>
 are some value literals of the <code>int</code> type.
-The <code>"Result: "</code> at line <i>39</i> is a value literal
+The <code>"Result: "</code> at line <i>30</i> is a value literal
 of the built-in <code>string</code> type.
 Value literals must be not identifiers.
 Please read <a href="basic-types-and-value-literals.html">basic types and their value literals</a>
@@ -175,11 +175,11 @@ Some other types (composite types) will be introduced later in other articles.
 </p>
 
 <p>
-Line <code>23</code> is an assignment.
+Line <code>27</code> is an assignment.
 Line <i>5</i> declares a named constant, <code>MaxRand</code>.
-Line <i>16</i> and line <i>33</i> declare three variables,
+Line <i>14</i> and line <i>27</i> declare three variables,
 with the standard variable declaration form.
-The variable <code>i</code>, <code>x</code> and <code>y</code> at line <i>37</i>
+The variable <code>i</code>, <code>x</code> and <code>y</code> at line <i>29</i>
 are declared with the short variable declaration form.
 Compilers will deduce that the types of <code>i</code>, <code>num</code>,
 <code>x</code> and <code>y</code> are all <code>int</code>.
@@ -190,20 +190,20 @@ value assignments and how to declare variables and named constants.
 
 <p>
 There are many operators are used in the program, such as the less-than
-comparison operator <code>&lt;</code> at line <i>18</i>,
-the equal-to operator <code>==</code> at line <i>40</i>,
-and the addition operator <code>+</code> at line <i>23</i> and line <i>40</i>.
+comparison operator <code>&lt;</code> at line <i>15</i>,
+the equal-to operator <code>==</code> at line <i>31</i>,
+and the addition operator <code>+</code> at line <i>17</i> and line <i>31</i>.
 The values involved in an operator operation are called operands.
 Please read <a href="operators.html">common operators</a> for more imformation
 More operators will be introduced in other articles later.
 </p>
 
 <p>
-At line <i>39</i> and line <i>40</i>, two built-in functions,
+At line <i>30</i> and line <i>31</i>, two built-in functions,
 <code>print</code> and <code>println</code>, are called.
 A custom function <code>StatRandomNumbers</code> is delcared from line
-<i>14</i> to line <i>29</i>, and it is called at line <i>37</i>.
-Line <i>22</i> also calls a function, <code>Intn</code>,
+<i>13</i> to line <i>23</i>, and it is called at line <i>29</i>.
+Line <i>16</i> also calls a function, <code>Intn</code>,
 which is a function declared in the <code>math/rand</code> standard package.
 A function call is a function operation.
 The input values used in a function call are called arguments.
@@ -225,7 +225,7 @@ The <code>main</code> entry function must be declared in a pakcage also
 called <code>main</code>.
 Line <i>3</i> imports a package, the <code>math/rand</code>
 standard code package. The function <code>Intn</code> delcared in this
-standard pacakge is called at line <i>22</i>.
+standard pacakge is called at line <i>16</i>.
 Please read <a href="packages-and-imports.html">code packages and package imports</a>
 for more information on how to organize code packages and import packages.
 </p>

--- a/articles/basic-code-elements-introduction.html
+++ b/articles/basic-code-elements-introduction.html
@@ -266,7 +266,7 @@ and only use neccessary comments in formal projects.
 <div>
 Like many other languages, Go also use a pair of braces (<code>{</code> and <code>}</code>)
 to form an explicit code block. In Go programming, coding style can't be
-arbitrary. For example, many of the starting curly braces (code>{</code>)
+arbitrary. For example, many of the starting curly braces (<code>{</code>)
 can't be put on the next line. If we modify the <code>StatRandomNumbers</code>
 function declartion in the above program as the following,
 the program will fail to compile.

--- a/articles/keywords-and-identifiers.html
+++ b/articles/keywords-and-identifiers.html
@@ -32,7 +32,7 @@ They can be categoried as four groups:
 	are used as parts in some composite type denotations.
 </li>
 <li>
-	<code>break</code>, <code>case</code>, <code>continue</code>, <code>default</code>, <code>else</code>, <code>fallthroigh</code>,
+	<code>break</code>, <code>case</code>, <code>continue</code>, <code>default</code>, <code>else</code>, <code>fallthrough</code>,
 	<code>for</code>, <code>goto</code>, <code>if</code>, <code>range</code>, <code>return</code>, <code>select</code> and <code>switch</code>
 	are used to control code flows.
 </li>


### PR DESCRIPTION
### article/basic-code-elements-introduction.html

1. Typo: inctoduce => introduce
2. Fix wrong number of lines
3. Line number: \<code\> => \<i\>
4. Syntax error: code\> => \<code\>

### articles/keywords-and-identifiers.html

1. Typo: fallthroigh => fallthrough