### PR TITLE
Grammar and typo fixes

### DIFF
--- a/articles/constants-and-variables.html
+++ b/articles/constants-and-variables.html
@@ -17,8 +17,8 @@ On the contrary, the type of a typed value is determined.
 <p>
 For most untyped values, each of them has one default type.
 The predeclared <code>nil</code> is the only untyped value
-which has not a default type.
-We can learn more about <code>nil</code> in other Go 101 articles later.
+which has no default type.
+We will learn more about <code>nil</code> in other Go 101 articles later.
 </p>
 
 <p>
@@ -80,7 +80,7 @@ Go compilers view <code>T(v)</code> as a typed value of type <code>T</code>.
 
 <p>
 The next section will introduce named constants.
-The basic value literals introudced in the last article is
+The basic value literals introduced in the last article is
 called literal constants, or unnamed constants.
 We will learn that each named constant also denote a literal constant
 in the next section.
@@ -308,7 +308,7 @@ the same as the literal it denotes.
 
 <div>
 
-We can delcared typed constants. Typed constants are all named.
+We can declare typed constants, typed constants are all named.
 In the following example, all the four declared constants are typed values.
 The types of <code>X</code> and <code>Y</code> are both <code>float32</code>
 and the types of <code>A</code> and <code>B</code> are both <code>int64</code>.
@@ -365,8 +365,8 @@ For each <code>uint</code> value has only 32 bits on 32-bit OSes.
 <pre class="line-numbers"><code class="language-go">const MaxUint uint = (1 << 64) - 1
 </code></pre>
 
-Then, how to declared a typed <code>uint</code> constant and bind
-the largest <code>uint</code> value to it? Use the following way.
+Then, to declare a typed <code>uint</code> constant and bind
+the largest <code>uint</code> value to it,
 
 <pre class="line-numbers"><code class="language-go">const MaxUint = ^uint(0)
 </code></pre>
@@ -377,7 +377,7 @@ and bind the largest <code>int</code> value to it.
 <pre class="line-numbers"><code class="language-go">const MaxInt = int(^uint(0) >> 1)
 </code></pre>
 
-We can also similar ways to get the number of bits of a native word,
+A similar method can be used to get the number of bits of a native word,
 and check the currrent OS is 32-bit or 64-bit.
 
 <pre class="line-numbers"><code class="language-go">const NativeWordBits = 32 << (^uint(0) >> 63) // 64 or 32
@@ -408,7 +408,7 @@ complete the following code
 
 	A, B = "Go", "language"
 	C, _
-	// In the above line, the blank identifier is needed.
+	// In the above line, the blank identifier is required.
 )
 </code></pre>
 
@@ -508,7 +508,7 @@ const (
 <p>
 Here, the <code>-</code> symbol is the subtraction operator,
 and the <code>&lt;&lt;</code> symbol is the left-shift operator.
-Both of the two operators will be introudced in the next article.
+Both of these operators will be introduced in the next article.
 </p>
 
 </div>
@@ -539,7 +539,7 @@ We also often call package-level variables as global variables.
 <p>
 There are two basic variable declaration forms,
 the standard one and the short one.
-The short form can only be used to delcared local variables.
+The short form can only be used to declare local variables.
 </p>
 
 <h4>Standard Variable Declarations Forms</h4>
@@ -552,7 +552,7 @@ Variable names must be <a href="keywords-and-identifiers.html#identifier">identi
 
 The following are some full standard declaration forms.
 In these declarations,
-the types and initial values of the decalred variables are all specified.
+the types and initial values of the declared variables are all specified.
 <pre class="line-numbers"><code class="language-go">var lang, website string = "Go", "https://golang.org"
 var compiled, dynamic bool = true, false
 var announceYear int = 2008
@@ -561,12 +561,12 @@ var announceYear int = 2008
 <p>
 As we have found, multiple variables can be declared together
 in one variable declaration.
-Please note, there can be most one type specified in a variable declaration.
+Please note, there can be just one type specified in a variable declaration.
 So the types of the multiple variables declared in the same declaration line must be identical.
 </p>
 
 <p>
-Full standard variable declaration forms are seldom used in practice, for they are some verbose.
+Full standard variable declaration forms are seldom used in practice, since they are verbose.
 In practice, the two standard variable declaration variant forms introduced
 below are used more often.
 In the two variants, either the types or the initial values of
@@ -619,13 +619,13 @@ by using <code>()</code>. For example:
 <p>
 The above example is formatted by using the <code>go fmt</code> command
 in the official Go SDK.
-In the above example. each of the three lines enclosed in <code>()</code>
-is called a variable specification.
+In the above example, each of the three lines are enclosed in <code>()</code>
+this is known as variable specification.
 </p>
 
 <p>
 Generally, declaring related variables together will
-make code get a better readability.
+make code more readable.
 </p>
 
 </div>
@@ -700,7 +700,7 @@ a = b = 123 // syntax error
 
 <div>
 We can also use short variable declaration forms to declare variables.
-Short variable declarations can only be used to delcare local variables.
+Short variable declarations can only be used to declare local variables.
 Let's view an example which uses some short variable declarations.
 
 <pre class="line-numbers"><code class="language-go">package main
@@ -728,12 +728,12 @@ func main() {
 There are several differences between short and standard variable declarations.
 <ol>
 <li>
-	In a short delcaration form, the "var" keyword and
+	In the short declaration form, the "var" keyword and
 	variable types must be omitted. And the assignment sign
 	must be <code>:=</code> instead of <code>=</code>.
 </li>
 <li>
-	In a short variable delcaration, old variables and new
+	In the short variable declaration, old variables and new
 	variables can mix at the left of <code>:=</code>. But there must be
 	at least one new variable at the left.
 </li>
@@ -767,7 +767,7 @@ in a standard variable declaration.
 <div>
 <p>
 Please note, for the standard Go compiler,
-local variables are not allowed declared but unused.
+local variables are not allowed to be declared and be unused.
 Package-level variables have no such limit.
 </p>
 
@@ -776,7 +776,7 @@ If a local variable is only ever used as destination values,
 it will also be viewed as unused.
 </p>
 
-For example, compiler the following program
+For example, compiling the following program,
 
 <pre class="line-numbers"><code class="language-go">package main
 
@@ -837,10 +837,10 @@ and <code>x = a+1</code>.
 
 <p>
 Here, the <code>+</code> symbol is the addition operator,
-which will be introudced in the next article. 
+which will be introduced in the next article. 
 </p>
 
-Pakcage-level variables can't be depended circularly in their declaration.
+Package-level variables can't be depended circularly in their declaration.
 The following code fails to compile.
 
 <pre class="line-numbers"><code class="language-go">var x, y = y, x
@@ -863,7 +863,7 @@ and learn other adressable and unadressable values from other articles later.
 
 <div>
 As above has mentioned, non-constant integer values can be converted to strings.
-Here introduces two more legal non-constant numeric values
+Here we introduce two more legal non-constant numeric values
 related conversion cases.
 <ul>
 <li>
@@ -883,7 +883,7 @@ And when converting a non-constant floating-point value to an integer,
 rounding is also allowed.
 If a non-constant floating-point value doesn't overflow an interger type
 the fraction part of the floating-point value will be discarded
-(towards zero) when it is converted to the interger type.
+(towards zero) when it is converted to the integer type.
 </p>
 
 <p>
@@ -893,7 +893,7 @@ In other words, the types of the destination and source values in an
 assignment must be identical if the two values are both basic values.
 If the type of the source basic value is not same as the type of
 the destination basic value, then the source value must be explicitly
-converted to the type of the distination value.
+converted to the type of the destination value.
 </p>
 
 In the following example, the intended implicit conversions
@@ -931,7 +931,7 @@ In Go, we can use a pair of <code>{</code> and <code>}</code> to form a code blo
 A code block can nest other code blocks.
 A variable or a named constant declared in an inner code block will shadow
 the variables and constants declared with the same name in outer code blocks.
-For examples, the following program declares three distinct varialbes,
+For examples, the following program declares three distinct variables,
 all of them are called <code>x</code>.
 An inner <code>x</code> shadows an outer one.
 
@@ -975,7 +975,7 @@ of the above example doesn't compile.
 </p>
 
 <p>
-Code blocks and identifier scopes will be explained detailedly in
+Code blocks and identifier scopes will be explained in detail
 <a href="blocks-and-scopes.html">blocks and scopes</a> later.
 </p>
 
@@ -985,20 +985,20 @@ Code blocks and identifier scopes will be explained detailedly in
 
 <p>
 Constant declarations can be viewed as enhanced <code>#define</code> macros in C.
-A constant declaration define a named constant which represents a literal.
+A constant declaration defines a named constant which represents a literal.
 All the occurances of a named constant will be replaced with the literal
 it represents at compile time.
 </p>
 
 <p>
 If the two operands of an operator operation are both constants,
-then the opeartion will be evaluated at compile time.
+then the operation will be evaluated at compile time.
 (Please read the next article
 <a href="operators.html">common operators</a> for details.)
 </p>
 
 <div>
-For example, at compile time, the follow code
+For example, at compile time, the following code
 
 <pre class="line-numbers"><code class="language-go">package main
 


### PR DESCRIPTION
fixes some grammar and typos in constants-and-variables.html
