### PR TITLE
memory-leaking: typo 'casued' -> 'caused'

### DIFF
--- a/articles/memory-leaking.html
+++ b/articles/memory-leaking.html
@@ -9,7 +9,7 @@ which may cause kind-of or real memory leaking.
 The remaining of the current article will list several such scenarios.
 </p>
 
-<h3>Kind-Of Memory Leaking Casued By Substrings</h3>
+<h3>Kind-Of Memory Leaking Caused By Substrings</h3>
 
 <div>
 <p>
@@ -93,7 +93,7 @@ The disadvantage of the third way is a little verbose
 
 </div>
 
-<h3>Kind-Of Memory Leaking Casued By Subslices</h3>
+<h3>Kind-Of Memory Leaking Caused By Subslices</h3>
 
 <div>
 Similarly to substrings, subslices may also cause kind-of memory leaking.
@@ -124,7 +124,7 @@ from being collected.
 
 </div>
 
-<h3>Kind-Of Memory Leaking Casued By Not Resetting Pointers In Dead Slice Elements</h3>
+<h3>Kind-Of Memory Leaking Caused By Not Resetting Pointers In Dead Slice Elements</h3>
 
 <div>
 In the following code, after the <code>g</code> function is called,
@@ -169,7 +169,7 @@ We often need to reset the pointers for some old slice elements in
 </div>
 
 <p class="anchor" id="hanging-goroutine"></p>
-<h3>Real Memory Leaking Casued By Hanging Goroutines</h3>
+<h3>Real Memory Leaking Caused By Hanging Goroutines</h3>
 
 <div>
 <p>


### PR DESCRIPTION
😃 couldn't resist. thanks for sharing the book!