### PR TITLE
typo

### DIFF
--- a/articles/channel.html
+++ b/articles/channel.html
@@ -577,7 +577,7 @@ both of the following two steps will be performed by the following order.
 [<u>Channel rule case D</u>]:
 after a channel is closed,
 channel receive operations on the channel will never block.
-The values in the the value buffer of the channel can still be received.
+The values in the value buffer of the channel can still be received.
 Once all the values in the value buffer are taken out and received,
 infinite zero values of the element type of the channel will received
 by any of following receive operations on the channel.
@@ -601,7 +601,7 @@ and the goroutine was blocked for being pushed into the queue at a
 then the goroutine will be resumed to running state at the step <i>9</i> of the
 <a href="#select-implementation"><code>select</code> control flow code block execution</a>.
 It may be dequeued from the corresponding goroutine queues of
-several goroutines involved in the the <code>select</code> control flow code block.
+several goroutines involved in the <code>select</code> control flow code block.
 </p>
 
 By the rules listed above, we can get some facts about the internal queues of a channel.


### PR DESCRIPTION
remove the duplicate `the`