### PR TITLE
typo: foloowing -> following

### DIFF
--- a/articles/control-flows.html
+++ b/articles/control-flows.html
@@ -743,7 +743,7 @@ is not the innermost loop control flow block containing
 the <code>continue</code> statement.
 </p>
 
-The foloowing is an example of using <code>break</code>
+The following is an example of using <code>break</code>
 and <code>continue</code> statements with labels.
 <pre class="line-numbers"><code class="language-go">package main
 


### PR DESCRIPTION
Hi. I found a trivial typo and fixed it. :)