### PR TITLE
Fix typos

### DIFF
--- a/articles/go-sdk.html
+++ b/articles/go-sdk.html
@@ -235,7 +235,7 @@ This bug has been fixed in Go SDK 1.11.
 </p>
 
 <p>
-The <code>godoc</code> command tries to list the documenrations of all the packages
+The <code>godoc</code> command tries to list the documentations of all the packages
 under the paths specified in the <code>GOPATH</code> environment variable.
 If you only want to view the documentations of the standard packages,
 you can set the <code>GOPATH</code> environment variable to a non-exist path
@@ -243,7 +243,7 @@ before running <code>godoc</code>, e. g. <code>GOPATH=nonexist godoc -http=:9999
 </p>
 
 <p>
-Currently (Go SDK 1.11), the <code>godoc</code> command doesn't support showing documenrations
+Currently (Go SDK 1.11), the <code>godoc</code> command doesn't support showing documentations
 of packages outside of the paths specified in the <code>GOPATH</code> environment variable.
 </p>
 

--- a/articles/packages-and-imports.html
+++ b/articles/packages-and-imports.html
@@ -211,7 +211,7 @@ In Go 101, only the following listed format verbs will be used.
 	<code>%x</code>, which will be replaced with the hex string representation of the corresponding argument.
 	Note, the hex string representations for values of some kinds of types are not defined.
 	Generally, the corresponding arguments of <code>%x</code> should be integers,
-	interger arrays or interger slices (arrays and slices will be explained in a later article).
+	integer arrays or integer slices (arrays and slices will be explained in a later article).
 </li>
 <li>
 	<code>%s</code>, which will be replaced with the string representation of the corresponding argument.


### PR DESCRIPTION
This PR fixes some typos:
1. `go-sdk.html`: From `documenration` to `documentation`
2. `packages-and-imports.html`: From `interger` to `integer`