### PR TITLE
Close <a> tag properly

### DIFF
--- a/articles/tips.html
+++ b/articles/tips.html
@@ -180,7 +180,7 @@ func main() {
 <p>
 In other words, a function call in a value assignment shouldn't affect
 the evaluation results of the non-function-call expressions in the same assignment.
-Please read <a href="evaluation-orders.html">evaluation orders in Go</code> for details.
+Please read <a href="evaluation-orders.html">evaluation orders in Go</a> for details.
 </p>
 
 </div>


### PR DESCRIPTION
This will fix html syntax error of unclosing `<a>` tag on https://go101.org/article/tips.html as below.

![image](https://user-images.githubusercontent.com/43811/48976286-27673200-f0c8-11e8-975b-9f2b1104d918.png)
