### PR TITLE
Update grammar and sentence structure

### DIFF
--- a/articles/control-flows-more.html
+++ b/articles/control-flows-more.html
@@ -3,9 +3,9 @@
 <p>
 This article will introduce goroutines and deferred function calls.
 Goroutine and deferred function call are two unique features in Go.
-Panic and recover mechanism will also be simply explained in this article.
-Not all knowledge relating to the these features is covered in the
-current article, more will be introduced in other articles later.
+This article also explains panic and recover mechanism.
+Not all knowledge relating to these features is covered in this
+article, more will be introduced in future articles.
 </p>
 
 <h3>Goroutines</h3>
@@ -13,16 +13,16 @@ current article, more will be introduced in other articles later.
 <p>
 Goroutines are also often called green threads.
 Green threads are maintained and scheduled by
-language runtime instead of operation systems.
+the language runtime instead of the operation systems.
 The cost, such as memory consumption and context switching,
-of a goroutine is much smaller than an OS thread.
-So it is not a problem for a Go program to maintain tons of thousands
+of a goroutine is much lesser than an OS thread.
+So, it is not a problem for a Go program to maintain tons of thousands
 goroutines at the same time, as long as the system memory is sufficient.
 </p>
 
 <p>
 Go doesn't support creating system threads in user code.
-So using goroutines is the only way to do concurrent programming
+So, using goroutines is the only way to do concurrent programming
 (program scope) in Go.
 </p>
 
@@ -30,8 +30,8 @@ So using goroutines is the only way to do concurrent programming
 Each Go program starts with only one goroutine, we call it the main goroutine.
 A goroutine can create new goroutines.
 It is super easy to create a new goroutine in Go,
-just make a function call follow a <code>go</code> keyword,
-then the function call will be executed in a new created goroutine.
+just make a function call following the <code>go</code> keyword.
+The function call will then be executed in a newly created goroutine.
 The new created goroutine will exit alongside the exit of the called function.
 </p>
 
@@ -72,7 +72,7 @@ func main() {
 </code></pre>
 
 Quite easy. Right? We do concurrent programming now!
-The above program may have three user created goroutines running
+The above program may have three user-created goroutines running
 simultaneously at its peak at run time.
 Let's run it. One possible output result:
 
@@ -210,7 +210,7 @@ is viewed as staying in running state.
 <p>
 When a new goroutine is created, it will enter running state automatically.
 Goroutines can only exit from running state, and never from blocking state.
-If, for any reason, a goroutine stays in blocking state for ever,
+If, for any reason, a goroutine stays in blocking state forever,
 then it will never exit.
 Such cases, except some rare ones, should be avoided in concurrent programming.
 </p>
@@ -219,7 +219,7 @@ Such cases, except some rare ones, should be avoided in concurrent programming.
 A blocking goroutine can only be unblocked by
 an operation made in another goroutine.
 If all goroutines in a Go program are in blocking state,
-then all of they will stay in blocking state for ever.
+then all of them will stay in blocking state forever.
 This can be viewed as an overall deadlock.
 When this happens in a program, the standard Go runtime
 will try to crash the program.
@@ -379,7 +379,7 @@ In fact, each goroutine maintain two call stacks, the normal-call stack and defe
 	following the <code>go</code> keyword.
 </li>
 <li>
-	The functions calls in the defer-call stack have no calling relations.
+	The function calls in the defer-call stack have no calling relations.
 </li>
 </ul>
 


### PR DESCRIPTION
This PR fixes grammar, spelling and sentence structure for the article in the follow manner:

1. Rephrases sentences where deemed appropriate
2. Replaces words with more appropriate ones such as changing `smaller` to `lesser`
3. Fixes grammar such as replacing `The functions calls in the ...` with `The function calls in the...`
4. Hyphenates words and removes spaces from words with no spaces in between such as changing `for ever` to `forever`