### PR TITLE
fix typo in article

### DIFF
--- a/articles/channel-closing.html
+++ b/articles/channel-closing.html
@@ -35,7 +35,7 @@ Yes, there is really not a built-in function to check whether or not a channel h
 There is indeed a simple method to check whether or not a channel is closed
 if you can make sure no values were (and will be) ever sent to the channel.
 The method has been shown in <a href="channel-use-cases.html#check-closed-status">the last article</a>.
-Here, for a better coherence, the methid is listed in the following example again.
+Here, for a better coherence, the method is listed in the following example again.
 <pre class="line-numbers"><code class="language-go">package main
 
 import "fmt"


### PR DESCRIPTION
I have been using one strategy to avoid multiple channel closes in some projects. And I see this is not listed in the article. Please have a view. Any comments are welcome.