### PR TITLE
Fixed a typo in basic code elements introductiuon

### DIFF
--- a/articles/basic-code-elements-introduction.html
+++ b/articles/basic-code-elements-introduction.html
@@ -195,7 +195,7 @@ comparison operator <code>&lt;</code> at line <i>19</i> and <i>21</i>,
 the equal-to operator <code>==</code> at line <i>37</i>,
 and the addition operator <code>+</code> at line <i>22</i> and line <i>37</i>.
 Yes, <code>+</code> at line <i>36</i> is not an operator,
-it is one charactor in a string literal.
+it is one character in a string literal.
 The values involved in an operator operation are called operands.
 Please read <a href="operators.html">common operators</a> for more information.
 More operators will be introduced in other articles later.


### PR DESCRIPTION
This change replaces word 'charactor' with 'character'. Bigger context:
"Yes, + at line 36 is not an operator, it is one charactor in a string literal"

Signed-off-by: Oleg Sidorov <me@whitebox.io>