### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "git clone https://github.com/go101/go101.git && cd go101 && git pull && go run ."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 **[Go 101 in Leanpub store](https://leanpub.com/go101)** | **[Go 101 in Apple Books store](https://itunes.apple.com/us/book/id1459984231)** | **[Go 101 in Kindle store](https://www.amazon.com/dp/B07Q3HWZ98)** | **[eBooks](https://github.com/go101/go101/releases)** | **[update history](UPDATES.md)** | **[wiki](https://github.com/go101/go101/wiki)**
+[![Run on Repl.it](https://repl.it/badge/github/go101/go101)](https://repl.it/github/go101/go101)
 
 ----
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@josephescamilla/go101-10).