### PR TITLE
fix a code comment in struct.html and a typo

### DIFF
--- a/articles/panic-and-recover-more.html
+++ b/articles/panic-and-recover-more.html
@@ -147,7 +147,7 @@ func main() {
 
 <p>
 As Goexit signals can't be cancelled,
-arguing whether a function call may associate with at most one or more than one Goexit signal is unecessary.
+arguing whether a function call may associate with at most one or more than one Goexit signal is unnecessary.
 </p>
 
 Although it is unusual, there might be multiple unrecovered panics coexisting in a goroutine at a time.

--- a/articles/struct.html
+++ b/articles/struct.html
@@ -295,7 +295,7 @@ func main() {
 	// Book{} is unaddressable, so is Book{}.Pages.
 	/*
 	Book{}.Pages = 123
-	p = &(Book{}.Pages) // <=> p = &(Book{}.Pages)
+	p = &(Book{}.Pages) // <=> p = &Book{}.Pages
 	*/
 }
 </code></pre>


### PR DESCRIPTION
fix a code comment to match the following note in struct.html
fix typo unecessary -> unnecessary in panic-and-recover-more.html