### PR TITLE
Update incorrect assumption in memory model article

### DIFF
--- a/articles/memory-model.html
+++ b/articles/memory-model.html
@@ -265,7 +265,7 @@ Go 1 memory model lists the following three channel related order guarantees.
 	happens before the (<b><i>n+m</i></b>)th successful send to that channel completes.
 	In particular, if that channel is unbuffered (<code>m == 0</code>),
 	the <b><i>n</i></b>th successful receive from that channel happens
-	before the <b><i>n</i></b>th successful send on that channel completes.
+	before the <b><i>n+1</i></b>th successful send on that channel completes.
 </li>
 <li>
 	The closing of a channel happens before a receive completes if


### PR DESCRIPTION
I think you meant the receive happens before the following send. It doesn't make sense otherwise. (Also, it violates rule 1).
TBH, the second assumption can be removed as it's not really an assumption since it can be derived from the first one. 

Maybe you can summarize them together to something along those lines:
A send on a channel happens before the corresponding receive from that channel completes. If the channel is buffered with a capacity of m, then the n-th receive where n<m has to complete before the n+m send.