### PR TITLE
Add an explanation

### DIFF
--- a/articles/channel-closing.html
+++ b/articles/channel-closing.html
@@ -550,7 +550,10 @@ In this example, the <b>channel closing principle</b> is still held.
 Please note that the buffer size (capacity) of channel <code>toStop</code> is one.
 This is to avoid the first notification is missed
 when it is sent before the moderator goroutine gets ready to receive notification
-from <code>toStop</code>.
+from <code>toStop</code> (When the moderator goroutine is not ready, 
+the first notification will be blocked from sending to the channel. 
+After that, another notifications come and can be selected when the moderator goroutine is ready. 
+That's why we can miss the first notification.).
 </p>
 
 We can also set the capacity of the <code>toStop</code> channel


### PR DESCRIPTION
Hello,

> This is to avoid the first notification is missed
when it is sent before the moderator goroutine gets ready to receive notification
from <code>toStop</code>.

When reading this path, I misunderstood the meaning, I thought that Go will ignore the message if the channel is not ready.
So I made this explanation. I hope it will have a clearer meaning.

Regards,
Huy Dang