### PR TITLE
articles/value-copy-cost: fix usage of sumY/sY and sumZ/sZ

### DIFF
--- a/articles/value-copy-cost.html
+++ b/articles/value-copy-cost.html
@@ -231,18 +231,18 @@ func Benchmark_Loop(b *testing.B) {
 
 func Benchmark_Range_OneIterVar(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sumZ = 0
+		sumY = 0
 		for j := range sY {
-			sumZ += sY[j].a
+			sumY += sY[j].a
 		}
 	}
 }
 
 func Benchmark_Range_TwoIterVar(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sumY = 0
-		for _, v := range sY {
-			sumY += v.a
+		sumZ = 0
+		for _, v := range sZ {
+			sumZ += v.a
 		}
 	}
 }


### PR DESCRIPTION
The benchmark in the article value-copy-cost mixes up the variables a bit. Fixed that and kept the order of variable declaration.

Great Work, thanks for this! 🚀 