### PR TITLE
unsafe.html: fix grammar

### DIFF
--- a/articles/unsafe.html
+++ b/articles/unsafe.html
@@ -261,7 +261,7 @@ When a Go program is running, Go runtime will
 by any value any more and collect the memory</a> allocated for these unused blocks,
 from time to time.
 Pointers play an important role in the check process.
-If a memory block is unreachable from (referenced by) any values still in using,
+If a memory block is unreachable from (referenced by) any values still in use,
 then Go runtime thinks it is an unused value and it can be safely garbage collected.
 </p>
 
@@ -304,7 +304,7 @@ func foo() {
 	// garbage collector can collect the memory
 	// allocated for it now. On the other hand, the
 	// int values referenced by p0 and p1 are still
-	// in using.
+	// in use.
 
 	// uintptr can participate arithmetic operations.
 	p2 += 2; p2--; p2--
@@ -316,7 +316,7 @@ func foo() {
 </code></pre>
 
 <p>
-In the above example, the fact that value <code>p2</code> is still in using can't guarantee
+In the above example, the fact that value <code>p2</code> is still in use can't guarantee
 that the memory block ever hosting the <code>int</code> value referenced by <code>z</code> has not been garbage collected yet.
 In other words, when <code>*(*int)(unsafe.Pointer(p2)) = 3</code> is executed, the memory block may be collected, or not.
 It is dangerous to dereference the address stored in value <code>p2</code> to an <code>int</code> value,
@@ -329,7 +329,7 @@ for it is possible that the memory block has been already reallocated for anothe
 https://github.com/golang/go/issues/32115
 -->
 <!--
-<h4>Fact 3: we can use a <code>runtime.KeepAlive</code> function call to mark a value as still in using (reachable) before the call</h4>
+<h4>Fact 3: we can use a <code>runtime.KeepAlive</code> function call to mark a value as still in use (reachable) before the call</h4>
 
 <i>(I decided to remove this fact from this article. This doesn't means the fact is not existing.
 It just means that the fact is not very relevant to this article.
@@ -383,8 +383,8 @@ In other words, the addresses of the values hosted on these memory blocks will c
 
 <div>
 <p>
-In the following example, the fact value <code>t</code> is still in using
-can't guarantee that the values referenced by value <code>t.y</code> are still in using.
+In the following example, the fact value <code>t</code> is still in use
+can't guarantee that the values referenced by value <code>t.y</code> are still in use.
 </p>
 
 <pre class="line-numbers"><code class="language-go">type T struct {


### PR DESCRIPTION
Hello, 
Minor grammar fix for unsafe.html. Should be "in use" instead of "in using"