### PR TITLE
pointer.html: fix memory size typo for 64-bit architectures.

### DIFF
--- a/articles/pointer.html
+++ b/articles/pointer.html
@@ -22,7 +22,7 @@ The size of a native word is 4 (bytes) on 32-bit architectures and 8 (bytes)
 on 64-bit architectures.
 So the theoretical maximum memory space size is 2<sup>32</sup> bytes,
 a.k.a. 4GB (1GB == 2<sup>30</sup> bytes), on 32-bit architectures,
-and is 2<sup>64</sup>GB (16 exabytes) on 64-bit architectures.
+and is 2<sup>64</sup> bytes a.k.a 16EB (1EB == 1024PB, 1PB == 1024TB, 1TB == 1024GB), on 64-bit architectures.
 </p>
 
 <p>


### PR DESCRIPTION
Signed-off-by: Bo Tao <boknowswiki@gmail.com>