### PR TITLE
Fix a typo

### DIFF
--- a/articles/unsafe.html
+++ b/articles/unsafe.html
@@ -470,7 +470,7 @@ type <code>T1</code> and <code>T2</code> by using this pattern.
 One example is the <code>math.Float64bits</code> function,
 which converts a <code>float64</code> value to an <code>uint64</code> value,
 without changing any bit in the <code>float64</code> value.
-The <code>math.Float64bits</code> function does reverse conversions.
+The <code>math.Float64frombits</code> function does reverse conversions.
 
 <pre class="line-numbers"><code class="language-go">func Float64bits(f float64) uint64 {
 	return *(*uint64)(unsafe.Pointer(&f))


### PR DESCRIPTION
https://go101.org/article/unsafe.html

It's `math.Float64frombits` converts uint64 to float64 rather than `math. Float64bits` does such conversion