### PR TITLE
Dark mode: make scrollbar dark for Firefox

### DIFF
--- a/web/static/go101/css/v97-dark.css
+++ b/web/static/go101/css/v97-dark.css
@@ -29,3 +29,7 @@ margin: 0 3px;
 vertical-align: top;
 font-size: 12px;
 }
+
+:root {
+    scrollbar-color: #333 #000;
+}


### PR DESCRIPTION
Before:

![2021-06-05-232710_356x519_scrot](https://user-images.githubusercontent.com/3514015/120904565-98064680-c655-11eb-94a1-a403e97bc064.png)

After:

![2021-06-05-232743_406x558_scrot](https://user-images.githubusercontent.com/3514015/120904595-ad7b7080-c655-11eb-8eb3-bf4fb4f0a09d.png)
