### PR TITLE
Fixes examples in `articles/packages-and-imports`

### DIFF
--- a/articles/packages-and-imports.html
+++ b/articles/packages-and-imports.html
@@ -112,7 +112,7 @@ import "fmt"
 import "math/rand"
 
 func main() {
-	fmt.Printf("Next random number is %v.\n", rand.Uint32())
+	fmt.Printf("Next pseudo-random number is always %v.\n", rand.Uint32())
 }
 </code></pre>
 
@@ -174,7 +174,7 @@ import (
 func main() {
 	 // Set the random seed.
 	rand.Seed(time.Now().UnixNano())
-	fmt.Printf("Next random number is %v.\n", rand.Uint32())
+	fmt.Printf("Next pseudo-random number is %v.\n", rand.Uint32())
 }
 </code></pre>
 


### PR DESCRIPTION
As described [L149](https://github.com/go101/go101/blob/f6d38236e667cc03be89056d1927d3cc00569ce8/articles/packages-and-imports.html#L149):

> The above program will always output:
> <pre class="output"><code>Next pseudo-random number is always 2596996162.
> </code></pre>

Which is incorrect, because it adds both `pseudo-` and `always` characters - and these do not exist in the provided example.

Also, I've updated the adjacent example using the `pseudo-` prefix - although not including the `always` word, because it's calling `rand.Seed` and it will change every time it's called.