### PR TITLE
articles: container - correct typo in `make()` call example

### DIFF
--- a/articles/container.html
+++ b/articles/container.html
@@ -2244,12 +2244,12 @@ qualified identifier in code and the <code>make</code> call only take two argume
 For example, it only works for the first case in the following code:
 
 <pre class="disable-line-numbers111"><code class="language-go">	// case 1:
-	var s = make{[]byte, 10000)
+	var s = make([]byte, 10000)
 	y = make([]T, len(s)) // works
 	copy(y, s)
 
 	// case 2:
-	var s = make{[]byte, 10000)
+	var s = make([]byte, 10000)
 	y = make([]T, len(s), len(s)) // not work
 	copy(y, s)
 


### PR DESCRIPTION
```
make{[]byte, 10000)
```
->
```
make([]byte, 10000)
```