### PR TITLE
feat: support `Sec-CH-Prefers-Color-Scheme` :crescent_moon: :sunny:

### DIFF
--- a/go-get.go
+++ b/go-get.go
@@ -124,5 +124,8 @@ func (go101 *Go101) ServeGoGetPages(w http.ResponseWriter, r *http.Request, root
 	} else {
 		w.Header().Set("Cache-Control", "max-age=50000") // about 14 hours
 	}
+	w.Header().Set("Vary", "Sec-CH-Prefers-Color-Scheme")
+	w.Header().Set("Accept-CH", "Sec-CH-Prefers-Color-Scheme")
+	w.Header().Set("Critical-CH", "Sec-CH-Prefers-Color-Scheme")
 	w.Write(page)
 }

--- a/go101.go
+++ b/go101.go
@@ -133,7 +133,7 @@ func (go101 *Go101) RenderArticlePage(w http.ResponseWriter, r *http.Request, gr
 			pageParams := map[string]interface{}{
 				"Article":       article,
 				"Title":         article.TitleWithoutTags,
-				"Theme":         go101.theme,
+				"Theme":         go101.selectTheme(r),
 				"IsLocalServer": isLocal,
 			}
 			t := retrievePageTemplate(Template_Article, !isLocal)
@@ -164,7 +164,22 @@ func (go101 *Go101) RenderArticlePage(w http.ResponseWriter, r *http.Request, gr
 	} else {
 		w.Header().Set("Cache-Control", "max-age=50000") // about 14 hours
 	}
+	w.Header().Set("Vary", "Sec-CH-Prefers-Color-Scheme")
+	w.Header().Set("Accept-CH", "Sec-CH-Prefers-Color-Scheme")
+	w.Header().Set("Critical-CH", "Sec-CH-Prefers-Color-Scheme")
 	w.Write(page)
+}
+
+func (go101 *Go101) selectTheme(r *http.Request) string {
+	userPreferredTheme := r.Header.Get("Sec-CH-Prefers-Color-Scheme")
+	selectedTheme := go101.theme
+	switch userPreferredTheme {
+	case "dark":
+		selectedTheme = "dark"
+	case "light":
+		selectedTheme = "light"
+	}
+	return selectedTheme
 }
 
 var H1, _H1 = []byte("<h1>"), []byte("</h1>")

--- a/redirects.go
+++ b/redirects.go
@@ -55,6 +55,8 @@ func (go101 *Go101) RedirectArticlePage(w http.ResponseWriter, r *http.Request, 
 		} else {
 			w.Header().Set("Cache-Control", "max-age=50000") // about 14 hours
 		}
+		w.Header().Set("Vary", "Sec-CH-Prefers-Color-Scheme")
+		w.Header().Set("Accept-CH", "Sec-CH-Prefers-Color-Scheme")
 		w.Write(page)
 	}
 


### PR DESCRIPTION
Extra info: https://web.dev/user-preference-media-features-headers/#demo-of-sec-ch-prefers-color-scheme

This change adds support for the go101 server to read and accept the `Sec-CH-Prefers-Color-Scheme` header, and serve a light or dark themed site according to user preference.

This only affects static serving and does not provide a functionality for the user to swap the color scheme dynamically. I used this approach so that we don't serve both versions of CSS, though a dynamic approach would probably the best one; in which case the CSS would have to be reviewed to use media queries.

Changes and suggestions welcome. This is my first time dealing with these "Vary" and "*-CH" headers so this might be improved.

could probably also use more constants rather than repeating myself but tbh I'm lazy 😄 