### PR TITLE
fix wrong slicing in the "article" template

### DIFF
--- a/web/templates/article
+++ b/web/templates/article
@@ -206,7 +206,7 @@ in the Leanpub book store.
 {{- $is_blog := (eq .Group "blog") -}}
 
 {{- $not_index_page := (ne .FilenameWithoutExt "101") -}}
-{{- $is_book_page := (or (lt (len .FilenameWithoutExt) 4) (ne (slice .FilenameWithoutExt 0 4) "100-")) -}}
+{{- $is_book_page := (or (lt (len .FilenameWithoutExt) 4) (ne (slice .FilenameWithoutExt 0 3) "100-")) -}}
 {{- $show_index := (and $not_index_page $is_book_page) -}}
 {{- $show_bookstore_links := (and $not_index_page) -}}
 


### PR DESCRIPTION
`article` template has a slicing with wrong index :smiley: 

Signed-off-by: Ji-Hyeon Gim <potatogim@potatogim.net>