### PR TITLE
Fix a sentence in packages-and-imports.html

### DIFF
--- a/pages/fundamentals/packages-and-imports.html
+++ b/pages/fundamentals/packages-and-imports.html
@@ -32,7 +32,7 @@ Some explanations:
 	The <code>main</code> entry function of a program must be put in a package named <code>main</code>.
 </li>
 <li>
-	The third line imports the <code>fmt</code> standard package by using the <code>import</code> is a keyword.
+	The third line imports the <code>fmt</code> standard package by using the <code>import</code> keyword.
 	The identifier <code>fmt</code> is the package name.
 	It is also used as the import name of, and represents, this standard package in the scope of containing source file.
 	(Import names will be explained a below section.)


### PR DESCRIPTION
Before it reads:
> The third line imports the `fmt` standard package by using the `import` is a keyword.

Which does not read quite right in English

This PR changes it to
> The third line imports the `fmt` standard package by using the `import` keyword.
