### PR TITLE
add one more reference for the tri-color gc algorithm

### DIFF
--- a/pages/fundamentals/memory-block.html
+++ b/pages/fundamentals/memory-block.html
@@ -445,7 +445,7 @@ and is modified a bit to make it clearer.
 
 <p><i>
 (About why the algorithm uses three colors instead of two colors, please search "write barrier golang" for details.
-Here only provides two references: <a href="https://github.com/golang/proposal/blob/master/design/17503-eliminate-rescan.md">eliminate STW stack re-scanning</a> and <a href="https://golang.org/src/runtime/mbarrier.go">mbarrier.go</a>.)
+Here only provides several references: <a href="https://github.com/golang/proposal/blob/master/design/17503-eliminate-rescan.md">eliminate STW stack re-scanning</a>, <a href="https://golang.org/src/runtime/mbarrier.go">mbarrier.go</a>, and <a href="https://stackoverflow.com/questions/2364274/tri-color-incremental-updating-gc-does-it-need-to-scan-each-stack-twice">Tri-Color Incremental Updating GC: Does it need to scan each stack twice?</a>.)
 </i></p>
 
 <p>


### PR DESCRIPTION
I was really confused about the question raised in this article (*Memory Blocks*): "why the algorithm uses three colors instead of two colors". So I spent some time searching for comprehensive answers, during which I found this Stack Overflow question.

Not only this question itself cover many aspects of the tri-color GC algorithm, the answer also elaborate some details which are not discussed in other articles. Consequently, it may be helpful for future readers to include this question as another reference.

Initially I planned to add more contents directly to this article, but as I'm not expert at the GC design and implementation, I may introduce some false information and mislead others. It's bad.

I may guess the reason why you introduced only two references from Go official docs and codes here, but I still think adding this (or even other) reference would help readers who have little knowledge about the GC before (like me).