### PR TITLE
Enable misspell linter; fix spelling mistakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+
+  main:
+    name: Main Process
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # https://github.com/marketplace/actions/setup-go-environment
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+
+      # https://github.com/golangci/misspell/tree/master#readme
+      - name: Install misspell
+        run: |
+          go install github.com/golangci/misspell/cmd/misspell@latest
+          misspell -v
+
+      - name: Run misspell
+        run: |
+          misspell pages

--- a/pages/apps-and-libs/gotv.html
+++ b/pages/apps-and-libs/gotv.html
@@ -135,16 +135,16 @@ go version go1.17.13 linux/amd64
 
 <h2>Set a bootstrap toolchain version</h2>
 
-<p>To build a toolchain verision, another already built toolchain version is needed to be used in the building process.
+<p>To build a toolchain version, another already built toolchain version is needed to be used in the building process.
 The other toolchain version is called the bootstrap version.</p>
 
 <p>Some facts:</p>
 
 <ul>
-<li>Toolchain versions &lt;= 1.12.17 are unable to be built with toochain versions &gt;= 1.16;</li>
-<li>Toolchain versions &lt;= 1.5.4 are uanable to be built with toolchain versions &gt;= 1.6;</li>
+<li>Toolchain versions &lt;= 1.12.17 are unable to be built with toolchain versions &gt;= 1.16;</li>
+<li>Toolchain versions &lt;= 1.5.4 are unable to be built with toolchain versions &gt;= 1.6;</li>
 <li>It is planned to <a href="https://github.com/golang/go/issues/44505">require a 1.17.13+ toolchain version to build 1.20+ toolchain versions</a>;</li>
-<li>It is proposed to <a href="https://github.com/golang/go/issues/54265">require a 1.20+ toolchain verison to build 1.22+ toolchain verisons</a>.</li>
+<li>It is proposed to <a href="https://github.com/golang/go/issues/54265">require a 1.20+ toolchain version to build 1.22+ toolchain versions</a>.</li>
 </ul>
 
 <p>Currently, GoTV uses the toolchain set in the <code>PATH</code> environment variable as the bootstrap version by default.

--- a/pages/apps-and-libs/gotv.md
+++ b/pages/apps-and-libs/gotv.md
@@ -144,7 +144,7 @@ Some facts:
 * Toolchain versions <= 1.12.17 are unable to be built with toochain versions >= 1.16;
 * Toolchain versions <= 1.5.4 are uanable to be built with toolchain versions >= 1.6;
 * It is planned to [require a 1.17.13+ toolchain version to build 1.20+ toolchain versions](https://github.com/golang/go/issues/44505);
-* It is proposed to [require a 1.20+ toolchain verison to build 1.22+ toolchain verisons](https://github.com/golang/go/issues/54265).
+* It is proposed to [require a 1.20+ toolchain version to build 1.22+ toolchain versions](https://github.com/golang/go/issues/54265).
 
 Currently, GoTV uses the toolchain set in the `PATH` environment variable as the bootstrap version by default.
 If `GOROOT_BOOTSTRAP` environment variable is set, then its value will be used.

--- a/pages/blog/2022-10-01-three-way-string-comparison.html
+++ b/pages/blog/2022-10-01-three-way-string-comparison.html
@@ -34,8 +34,8 @@ on most architectures.</p>
 }
 </code></pre>
 
-<p>The <code>strings.Compare</code> implementation is comparatively inefficent.
-Specifically, it is less efficent when the two string operands are not equal but their lengths are equal.</p>
+<p>The <code>strings.Compare</code> implementation is comparatively inefficient.
+Specifically, it is less efficient when the two string operands are not equal but their lengths are equal.</p>
 
 <p>Benchmark code constantly shows <code>strings.Compare</code> uses 2x CPU time of <code>bytes.Compare</code>
 when comparing unequal same-length byte sequences (we view both strings and byte slices as byte sequences here).</p>
@@ -45,7 +45,7 @@ is some interesting. The comment suggests that we should not use
 <code>strings.Compare</code> in Go at all, but no alternative efficient ways are available now yet
 (ironically, this function is used in <a href="https://github.com/golang/go/blob/go1.19/src/cmd/go/internal/modindex/read.go#L822">Go toolchain code</a> and recommended by <a href="https://github.com/golang/go/blob/go1.19/src/sort/search.go#L88-L99">a standard library function</a>).
 It mentions that the compiler should make special optimizations to automatically
-convert the code using comparision operators into internal optimized three-way comparisons if possible.
+convert the code using comparison operators into internal optimized three-way comparisons if possible.
 However, such compiler optimizations have never been made,
 and there are no plans to make such optimizations yet as far as I know.
 Personally, I doubt such optimizations are feasible to be made for any use case.

--- a/pages/blog/2022-10-01-three-way-string-comparison.md
+++ b/pages/blog/2022-10-01-three-way-string-comparison.md
@@ -41,8 +41,8 @@ func Compare(a, b []byte) int {
 }
 ```
 
-The `strings.Compare` implementation is comparatively inefficent.
-Specifically, it is less efficent when the two string operands are not equal but their lengths are equal.
+The `strings.Compare` implementation is comparatively inefficient.
+Specifically, it is less efficient when the two string operands are not equal but their lengths are equal.
 
 [strings.Compare]: https://github.com/golang/go/blob/go1.19/src/strings/compare.go#L7-L28
 [bytes.Compare]: https://github.com/golang/go/blob/go1.19/src/bytes/bytes.go#L23-L28
@@ -56,7 +56,7 @@ is some interesting. The comment suggests that we should not use
 `strings.Compare` in Go at all, but no alternative efficient ways are available now yet
 (ironically, this function is used in [Go toolchain code] and recommended by [a standard library function]).
 It mentions that the compiler should make special optimizations to automatically
-convert the code using comparision operators into internal optimized three-way comparisons if possible.
+convert the code using comparison operators into internal optimized three-way comparisons if possible.
 However, such compiler optimizations have never been made,
 and there are no plans to make such optimizations yet as far as I know.
 Personally, I doubt such optimizations are feasible to be made for any use case.

--- a/pages/fundamentals/100-updates.html
+++ b/pages/fundamentals/100-updates.html
@@ -57,7 +57,7 @@
 
 <ul>
 <li>describe more about <a href="https://go101.org/article/details.html#reflect-deep-equal">reflect.DeepEqual</a> related details.</li>
-<li>add <a href="https://go101.org/article/exceptions.html#code-block-following-else">a new syntax execption</a>.</li>
+<li>add <a href="https://go101.org/article/exceptions.html#code-block-following-else">a new syntax exception</a>.</li>
 </ul>
 
 <h3>1.15.a (2020/Aug/07)</h3>

--- a/pages/fundamentals/100-updates.md
+++ b/pages/fundamentals/100-updates.md
@@ -39,7 +39,7 @@
 ### 1.15.b (2020/Oct/09)
 
 * describe more about [reflect.DeepEqual](https://go101.org/article/details.html#reflect-deep-equal) related details.
-* add [a new syntax execption](https://go101.org/article/exceptions.html#code-block-following-else).
+* add [a new syntax exception](https://go101.org/article/exceptions.html#code-block-following-else).
 
 ### 1.15.a (2020/Aug/07)
 

--- a/pages/fundamentals/container.html
+++ b/pages/fundamentals/container.html
@@ -2342,7 +2342,7 @@ is a zero value literal representation of <code>T</code>.
 <h4>Clone slices</h4>
 
 <div>
-For the current Go verison (1.21), the simplest way to clone a slice is:
+For the current Go version (1.21), the simplest way to clone a slice is:
 <pre class="disable-line-numbers111"><code class="language-go">sClone := append(s[:0:0], s...)
 </code></pre>
 

--- a/pages/fundamentals/exceptions.html
+++ b/pages/fundamentals/exceptions.html
@@ -477,7 +477,7 @@ func main() {
 The basic rule:
 <div class="alert alert-info">
 In a type argument list, all type arguments are enclosed in square brackets
-and they are seperated by commas in the list.
+and they are separated by commas in the list.
 </div>
 
 Exception:

--- a/pages/fundamentals/interface.html
+++ b/pages/fundamentals/interface.html
@@ -88,12 +88,12 @@ type ReadWriteCloser = interface {
 }
 
 // This interface embeds an approximation type. Its type
-// set inlcudes all types whose underlying type is []byte.
+// set includes all types whose underlying type is []byte.
 type AnyByteSlice = interface {
 	~[]byte
 }
 
-// This interface embeds a type union. Its type set inlcudes
+// This interface embeds a type union. Its type set includes
 // 6 types: uint, uint8, uint16, uint32, uint64 and uintptr.
 type Unsigned interface {
 	uint | uint8 | uint16 | uint32 | uint64 | uintptr

--- a/pages/fundamentals/panic-and-recover-more-newer.html
+++ b/pages/fundamentals/panic-and-recover-more-newer.html
@@ -93,7 +93,7 @@ BTW, the <code>runtime.Goexit()</code> function is not intended to be called in 
 </p>
 </div>
 
-<a class="anchor" id="function-call-assosiations"></a>
+<a class="anchor" id="function-call-associations"></a>
 <h3>Associating Panics of Function Calls</h3>
 <div>
 
@@ -250,7 +250,7 @@ The <code>runtime.Goexit</code> call in the end acts as an ultimate recover oper
 import "runtime"
 
 func f() {
-	// The Goexit signal repalces the "bye"
+	// The Goexit signal replaces the "bye"
 	// panic as the final (harmless) panic.
 	defer runtime.Goexit()
 	panic("bye")
@@ -345,7 +345,7 @@ showing the first condition case in the last article.
 Most of the <code>recover</code> calls in the first example of the current section satisfy
 either the second or the third conditions mentioned in Go specification,
 except the first call. Yes, here, the current descriptions are not precise yet.
-The thrid condition should be described as 
+The third condition should be described as
 
 <ul>
 <li>
@@ -421,7 +421,7 @@ and the newest unrecovered panic is not a Goexit signal.
 An effective <code>recover</code> call disassociates the
 newest unrecovered panic from its associating function call,
 and returns the value passed to the <code>panic</code> call
-which produced the newest unrecovered panic. 
+which produced the newest unrecovered panic.
 </div>
 
 </div>

--- a/pages/fundamentals/panic-and-recover-more-old.html
+++ b/pages/fundamentals/panic-and-recover-more-old.html
@@ -102,7 +102,7 @@ func f3() int {
 </p>
 </div>
 
-<a class="anchor" id="function-call-assosiations"></a>
+<a class="anchor" id="function-call-associations"></a>
 <h3>Associating Panics and Goexit Signals of Function Calls</h3>
 <div>
 

--- a/pages/fundamentals/panic-and-recover-more.html
+++ b/pages/fundamentals/panic-and-recover-more.html
@@ -93,7 +93,7 @@ BTW, the <code>runtime.Goexit()</code> function is not intended to be called in 
 </p>
 </div>
 
-<a class="anchor" id="function-call-assosiations"></a>
+<a class="anchor" id="function-call-associations"></a>
 <h3>Associating Panics and Goexit Signals of Function Calls</h3>
 <div>
 
@@ -428,7 +428,7 @@ showing the first condition case in the last article.
 Most of the <code>recover</code> calls in the first example of the current section satisfy
 either the second or the third conditions mentioned in Go specification,
 except the first call. Yes, here, the current descriptions are not precise yet.
-The thrid condition should be described as 
+The third condition should be described as 
 
 <ul>
 <li>

--- a/pages/fundamentals/reflection.html
+++ b/pages/fundamentals/reflection.html
@@ -809,7 +809,7 @@ reflectutil
 ======================
 
 generally, reflect can do any things non-reflect ways can do (not including the unsafe ways)
-reflect even can do non-relfect ways can't do.
+reflect even can do non-reflect ways can't do.
 * SetLen and SetCap
 * select any number of cases
 * get the kind of a value

--- a/pages/fundamentals/tips.html
+++ b/pages/fundamentals/tips.html
@@ -26,7 +26,7 @@ Index
 	<a class="index" href="#memclr">We can use the memclr optimization to reset some contiguous elements in an array or slice.</a>
 </li>
 <li>
-	<a class="index" href="#check-method-existance">How to check if a value has a method without importing the <code>reflect</code> package?</a>
+	<a class="index" href="#check-method-existence">How to check if a value has a method without importing the <code>reflect</code> package?</a>
 </li>
 <li>
 	<a class="index" href="#clone-slice-efficiently-and-perfectly">How to efficiently and perfectly clone a slice?</a>
@@ -310,7 +310,7 @@ Please read <a href="container.html#memclr">the <code>memclr</code> optimization
 
 
 
-<a class="anchor" id="check-method-existance"></a>
+<a class="anchor" id="check-method-existence"></a>
 <h3>How to check if a value has a method without importing the <code>reflect</code> package?</h3>
 
 <div>

--- a/pages/fundamentals/type-embedding.html
+++ b/pages/fundamentals/type-embedding.html
@@ -639,7 +639,7 @@ and the embedding is legal,
 	for each method of the embedded type <code>T</code>,
 	if the selectors to that method neither collide with nor are shadowed
 	by other selectors, then compilers will implicitly declare
-	a corresponding method with the same specificaiton
+	a corresponding method with the same specification
 	for the embedding struct type <code>S</code>.
 	And consequently, compilers will also
 	<a href="method.html#implicit-pointer-methods">implicitly declare
@@ -649,7 +649,7 @@ and the embedding is legal,
 	for each method of the pointer type <code>*T</code>,
 	if the selectors to that method neither collide with nor are shadowed
 	by other selectors, then compilers will implicitly declare
-	a corresponding method with the same specificaiton for the pointer type <code>*S</code>.
+	a corresponding method with the same specification for the pointer type <code>*S</code>.
 </li>
 </ul>
 

--- a/pages/fundamentals/type-system-overview.html
+++ b/pages/fundamentals/type-system-overview.html
@@ -201,7 +201,7 @@ func f() {
 Please note that,
 from Go 1.9 to Go 1.17, the Go specification ever thought predeclared
 built-in types are defined types.
-But since Go 1.18, the Go specificaiton clarifies that
+But since Go 1.18, the Go specification clarifies that
 predeclared built-in types are not defined types.
 </p>
 </div>

--- a/pages/fundamentals/unsafe.html
+++ b/pages/fundamentals/unsafe.html
@@ -1122,7 +1122,7 @@ which is a bit safer (but a bit slower) than the way shown in pattern 1.
 Similarly, please make sure not to modify the bytes in the argument byte slice if the result string still survives.
 </p>
 
-BTW, let's view a bad example which voilates the principle of pattern 3
+BTW, let's view a bad example which violates the principle of pattern 3
 (the example is borrowed from one slack comment posted by Bryan C. Mills):
 
 <pre class="line-numbers"><code class="language-go">package main

--- a/pages/generics/555-type-constraints-and-parameters.md
+++ b/pages/generics/555-type-constraints-and-parameters.md
@@ -522,7 +522,7 @@ of a generic type specification declares a single type parameter
 which constraint presents in simplified form and starts with `*` or `(`.
 
 <!--
-Either the spec is not accurate or the implementaiton is still not perfect yet.
+Either the spec is not accurate or the implementation is still not perfect yet.
 
 type bar[T **string] struct{} // *string (type) is not an expression
 -->


### PR DESCRIPTION
This PR adds running of the [misspell](https://github.com/golangci/misspell) tool for checking typos.