### PR TITLE
fix quizzes slice-2 code error

### DIFF
--- a/pages/quizzes/slice-2.html
+++ b/pages/quizzes/slice-2.html
@@ -99,7 +99,7 @@ func main() {
 	var x = []string{"A", "B", "C"}
 
 	for i, s := range x {
-		print(i, s, " ")
+		print(i, s, ",")
 		x = append(x, "Z")
 		x[i+1] = "Z"
 	}


### PR DESCRIPTION
> The original quiz prints `0A,1B,2C,` ...

if it prints `0A,1B,2C,` then it should be `,` not ` `