### PR TITLE
fix(control-flow): typo of `existed`

### DIFF
--- a/pages/fundamentals/control-flows-more.html
+++ b/pages/fundamentals/control-flows-more.html
@@ -406,7 +406,7 @@ must be discarded in the function call statement.
 <p>
 When a defer statement is executed, the deferred function call is not executed immediately.
 Instead, it is pushed into a deferred call queue maintained by its caller goroutine.
-After a function call <code>fc(...)</code> returns (but has not fully existed yet)
+After a function call <code>fc(...)</code> returns (but has not fully exited yet)
 and enters its <a href="function-declarations-and-calls.html#exiting-phase">exiting phase</a>,
 all the deferred function calls pushed into the deferred call queue
 during executing the function call will be removed from the deferred call queue and executed,


### PR DESCRIPTION
Fix #274 