### PR TITLE
Fix(concurrent-atomic-operation): typo

### DIFF
--- a/pages/fundamentals/concurrent-atomic-operation.html
+++ b/pages/fundamentals/concurrent-atomic-operation.html
@@ -91,7 +91,7 @@ func (*Int32) CompareAndSwap(old, new int32) (swapped bool)
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-Since Go 1.18, Go has already supported custom generics. And some standard packages started to adopt custom generics since Go 1.19. The <code class="tmd-code-span">sync/atomic</code> package is one of these packages. The <code class="tmd-code-span">Pointer[T any]</code> type introudced in this package by Go 1.19 is a generic type. Its methods are listed below.
+Since Go 1.18, Go has already supported custom generics. And some standard packages started to adopt custom generics since Go 1.19. The <code class="tmd-code-span">sync/atomic</code> package is one of these packages. The <code class="tmd-code-span">Pointer[T any]</code> type introduced in this package by Go 1.19 is a generic type. Its methods are listed below.
 </div>
 <p></p>
 <pre class="tmd-code line-numbers">

--- a/pages/fundamentals/concurrent-atomic-operation.tmd
+++ b/pages/fundamentals/concurrent-atomic-operation.tmd
@@ -91,7 +91,7 @@ func (*Int32) CompareAndSwap(old, new int32) (swapped bool)
 Since Go 1.18, Go has already supported custom generics.
 And some standard packages started to adopt custom generics since Go 1.19.
 The `sync/atomic` package is one of these packages.
-The `Pointer[T any]` type introudced in this package by Go 1.19 is a generic type.
+The `Pointer[T any]` type introduced in this package by Go 1.19 is a generic type.
 Its methods are listed below.
 
 @@@ .line-numbers


### PR DESCRIPTION
misspelled introduced