### PR TITLE
grammar_fixes for go_fundamentals

### DIFF
--- a/pages/fundamentals/function-declarations-and-calls.tmd
+++ b/pages/fundamentals/function-declarations-and-calls.tmd
@@ -73,14 +73,14 @@ func SquaresOfSumAndDiff(a int64, b int64) (int64, int64) {
 
 In fact, if all the parameters are never used within the corresponding function body,
 the names in the parameter declaration list of a function declaration
-can be also be omitted all together.
+can also be omitted all together.
 However, anonymous parameters are rarely used in practice.
 
 Although it looks the parameter and result variables are declared
 outside of the body of a function declaration, they are viewed as
 general local variables within the function body.
 The difference is that local variables with non-blank names declared
-within a function body must be ever used in the function body.
+within a function body must always be used in the function body.
 Non-blank names of top-level local variables, parameters and results
 in a function declaration can't be duplicated.
 

--- a/pages/fundamentals/packages-and-imports.tmd
+++ b/pages/fundamentals/packages-and-imports.tmd
@@ -190,7 +190,7 @@ Some explanations:
 
 ###+++++++++++ More About `fmt.Printf` Format Verbs
 
-As the above has mentioned, if there is one format verb in the first argument
+As mentioned above, if there is one format verb in the first argument
 of a `fmt.Printf` call, it will be replaced with the string
 representation of the second argument.
 In fact, there can be multiple format verbs in the first `string`
@@ -403,8 +403,8 @@ a meaningful name other than its package name, `main`.
 
 There can be multiple functions named as `init` declared in a package,
 even in a source code file.
-The functions named as `init` must have not any
-input parameters and return results.
+The functions named as `init` must neither have any
+input parameters nor return results.
 
 Note, at the top package-level block, the `init` identifier
 can only be used in function declarations.
@@ -615,7 +615,7 @@ package main
 import _ "net/http/pprof"
 
 func main() {
-	... // do somethings
+	... // do some things
 }
 '''
 

--- a/pages/fundamentals/pointer.tmd
+++ b/pages/fundamentals/pointer.tmd
@@ -329,7 +329,7 @@ the following facts exist:
    type `Ta` can be indirectly converted to type `Tb`
    by nesting three explicit conversions, `Tb((*MyInt)((*int64)(pa)))`.
 
-None values of these pointer types can be converted to type `*uint64`, in any safe ways.
+None of these pointer types can be converted to type `*uint64`, in any safe ways.
 
 ###----------- A pointer value can't be compared with values of an arbitrary pointer type
 

--- a/pages/fundamentals/summaries.tmd
+++ b/pages/fundamentals/summaries.tmd
@@ -41,7 +41,7 @@ Types whose values may have indirect underlying parts:
 *  interface types
 
 The answer is based on the implementation of the standard Go compiler/runtime.
-In fact, whether or not function values may have indirect underlying parts is hardly to prove,
+In fact, whether or not function values may have indirect underlying parts is hard to prove,
 and string values and interface values should be viewed as values without indirect underlying parts in logic.
 Please read __value parts__ for details.
 


### PR DESCRIPTION
Just minor grammar fixes. Not very important. Will do more if allowed.