### PR TITLE
grammatical errors in channel.html

### DIFF
--- a/pages/fundamentals/channel.html
+++ b/pages/fundamentals/channel.html
@@ -173,7 +173,7 @@ Query the value buffer capacity of the channel by using the following function c
 <code class="language-go">cap(ch)
 </code></pre>
 <div class="tmd-usual">
-where <code class="tmd-code-span">cap</code> is a built-in function which has ever been introduced in <a href="container.html#cap-len">containers in Go</a>. The return result of a <code class="tmd-code-span">cap</code> function call is an <code class="tmd-code-span">int</code> value.
+where <code class="tmd-code-span">cap</code> is a built-in function which has been introduced in <a href="container.html#cap-len">containers in Go</a>. The return result of a <code class="tmd-code-span">cap</code> function call is an <code class="tmd-code-span">int</code> value.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -184,7 +184,7 @@ Query the current number of values in the value buffer (or the length) of the ch
 <code class="language-go">len(ch)
 </code></pre>
 <div class="tmd-usual">
-where <code class="tmd-code-span">len</code> is a built-in function which also has ever been introduced before. The return value of a <code class="tmd-code-span">len</code> function call is an <code class="tmd-code-span">int</code> value. The result length is the number of elements which have already been sent successfully to the queried channel but haven't been received (taken out) yet.
+where <code class="tmd-code-span">len</code> is a built-in function which also has been introduced before. The return value of a <code class="tmd-code-span">len</code> function call is an <code class="tmd-code-span">int</code> value. The result length is the number of elements which have already been sent successfully to the queried channel but haven't been received (taken out) yet.
 </div>
 </li>
 </ol>


### PR DESCRIPTION
has ever been introduced

Has ever been is awkward flow. Removing the ever smoothens things up.