### PR TITLE
Update Go wiki links

### DIFF
--- a/pages/fundamentals/channel-use-cases.html
+++ b/pages/fundamentals/channel-use-cases.html
@@ -1231,7 +1231,7 @@ One of above section has shown how to use try-send to do <a href="#peak-limiting
 </div>
 <p></p>
 <div class="tmd-usual">
-The following shows such an example borrowed from jh oh <a href="https://github.com/golang/go/wiki/RateLimiting">the official Go wiki</a>. In this example, the number of handled requests in any one-minute duration will not exceed 200.
+The following shows such an example borrowed from jh oh <a href="https://go.dev/wiki/RateLimiting">the official Go wiki</a>. In this example, the number of handled requests in any one-minute duration will not exceed 200.
 </div>
 <p></p>
 <p></p>

--- a/pages/fundamentals/channel-use-cases.tmd
+++ b/pages/fundamentals/channel-use-cases.tmd
@@ -1223,7 +1223,7 @@ The following shows such an example borrowed from jh oh __the official Go wiki__
 In this example, the number of handled requests in any one-minute duration will not exceed 200.
 
     === peak limiting :: #peak-limiting
-    === the official Go wiki :: https://github.com/golang/go/wiki/RateLimiting
+    === the official Go wiki :: https://go.dev/wiki/RateLimiting
 
 @@@ .line-numbers;must-line-numbers
 ''' go

--- a/pages/fundamentals/go-toolchain.tmd
+++ b/pages/fundamentals/go-toolchain.tmd
@@ -82,7 +82,7 @@ In Go Toolchain 1.11, the Go modules feature is
 In Go Toolchain 1.11, an experimental feature, Go modules, is supported.
 The Go modules feature lets us put our Go projects freely in any folder.
 We can get more module related information from
-__href="https://github.com/golang/go/wiki/Modules">this wiki page__.
+__href="https://go.dev/wiki/Modules">this wiki page__.
 
 Note, since Go Toolchain 1.13,
 the Go modules feature becomes as the preferred mode (to the old `GOPATH` mode).

--- a/pages/fundamentals/more.html
+++ b/pages/fundamentals/more.html
@@ -18,7 +18,7 @@ We can use <code class="tmd-code-span">go test</code> command in Go Toolchain to
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-<a href="https://github.com/golang/go/wiki/Performance">Profiling Go programs</a>.
+<a href="https://go.dev/wiki/Performance">Profiling Go programs</a>.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -118,7 +118,7 @@ We can call C code from Go code, and vice versa, through the cgo mechanism. Plea
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-<a href="https://github.com/golang/go/wiki/cgo">cgo on Go wiki</a>
+<a href="https://go.dev/wiki/cgo">cgo on Go wiki</a>
 </div>
 </li>
 </ul>
@@ -141,7 +141,7 @@ The standard Go compiler supports cross-platform compiling. By setting the <code
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-<a href="https://github.com/golang/go/wiki/WindowsCrossCompiling">Building windows go programs on linux</a>.
+<a href="https://go.dev/wiki/WindowsCrossCompiling">Building windows go programs on linux</a>.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -152,7 +152,7 @@ The standard Go compiler supports cross-platform compiling. By setting the <code
 </ul>
 <p></p>
 <div class="tmd-usual">
-In particular, since Go 1.11, Go Toolchain starts to support WebAssembly as a new kind of GOARCH. Please read <a href="https://github.com/golang/go/wiki/WebAssembly">this wiki article</a> for details.
+In particular, since Go 1.11, Go Toolchain starts to support WebAssembly as a new kind of GOARCH. Please read <a href="https://go.dev/wiki/WebAssembly">this wiki article</a> for details.
 </div>
 <p></p>
 <p></p>

--- a/pages/fundamentals/more.tmd
+++ b/pages/fundamentals/more.tmd
@@ -13,7 +13,7 @@ Test source file names must end with `_test.go`.
 Go Toolchain also supports profiling Go programs.
 Please read the following articles for more details.
 *
-   __Profiling Go programs`` https://github.com/golang/go/wiki/Performance__.
+   __Profiling Go programs`` https://go.dev/wiki/Performance__.
 *
    __The testing standard package`` https://golang.org/pkg/testing/__.
 *
@@ -78,7 +78,7 @@ Please follow the following links for details.
 *
    __C? Go? Cgo!`` https://blog.golang.org/c-go-cgo__
 *
-   __cgo on Go wiki`` https://github.com/golang/go/wiki/cgo__
+   __cgo on Go wiki`` https://go.dev/wiki/cgo__
 
 It is possible to use C++ libraries through cgo by wrapping C++ libraries as C functions.
 
@@ -95,14 +95,14 @@ before running the `go build` command,
 we can build a Windows executable on a Linux machine, and vice versa.
 Please read the following articles for details.
 *
-   __Building windows go programs on linux`` https://github.com/golang/go/wiki/WindowsCrossCompiling__.
+   __Building windows go programs on linux`` https://go.dev/wiki/WindowsCrossCompiling__.
 *
    __The current supported target operating systems and compilation architectures`` https://golang.org/doc/install/source#environment__.
 
 In particular, since Go 1.11, Go Toolchain starts to support WebAssembly as a new kind of GOARCH.
 Please read __this wiki article__ for details.
 
-    === this wiki article :: https://github.com/golang/go/wiki/WebAssembly
+    === this wiki article :: https://go.dev/wiki/WebAssembly
 
 ###+++++++++++ Compiler Directives
 

--- a/pages/fundamentals/packages-and-imports.tmd
+++ b/pages/fundamentals/packages-and-imports.tmd
@@ -279,7 +279,7 @@ By context, different Go Toolchain versions interpret `auto`
 as either `on` or `off` by different rules.
 Please check __the official wiki__ for details.
 
-    === the official wiki :: https://github.com/golang/go/wiki/Modules
+    === the official wiki :: https://go.dev/wiki/Modules
 
 If a package is contained within a `GOPATH/src` directory,
 and the modules feature is off, then its import path is the relative path to


### PR DESCRIPTION
The [Go wiki on GitHub](https://github.com/golang/go/wiki) has been moved to [go.dev](https://go.dev/wiki), see http://go.dev/issue/61940.

E.g., the page https://github.com/golang/go/wiki/RateLimiting states:
<img width="650" height="243" alt="RateLimitin wiki page" src="https://github.com/user-attachments/assets/ffc92d5a-f8c9-4337-a6c2-4a423f895ab4" />
