### PR TITLE
Refactor by removing the use of deprecated functions

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
@@ -27,7 +28,7 @@ func genStaticFiles(rootURL string) {
 
 	_, err = os.Stat(fullPath("web", "static", "go101"))
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			log.Fatal("File web/static/go101 not found. Not run in go101 folder?")
 		}
 		log.Fatal(err)

--- a/go101-embed.go
+++ b/go101-embed.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"embed"
-	//"errors"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -56,7 +56,7 @@ func collectPageGroups() map[string]*PageGroup {
 					urlGroup = "/" + group
 				}
 				handler = http.StripPrefix(urlGroup+"/res/", http.FileServer(http.FS(resFiles)))
-			} else if !os.IsNotExist(err) { // !errors.Is(err, os.ErrNotExist) {
+			} else if !errors.Is(err, fs.ErrNotExist) {
 				log.Println(err)
 			}
 


### PR DESCRIPTION
This PR refactors generator's code to avoid deprecated functions:

- Replace `os.IsNotExist(err)` with `errors.Is(err, fs.ErrNotExist)`, see https://pkg.go.dev/os#IsNotExist.
- Replace deprecated `io/ioutil` with the same functions from the `os` package.