### PR TITLE
Add missed changes for tmd and html

### DIFF
--- a/pages/apps-and-libs/golds.tmd
+++ b/pages/apps-and-libs/golds.tmd
@@ -5,7 +5,7 @@ a Go docs generator, and a Go code reader.
 
 -  Demo: __docs and source code of standard packages__
    (generated with `GOEXPERIMENT=arenas,jsonv2 golds -gen -nouses -only-list-exporteds -render-doclinks -theme=dark std`).
--  Code is __hosted on Github__. Any feedback, including PR and bug reports, are welcome.
+-  Code is __hosted on GitHub__. Any feedback, including PR and bug reports, are welcome.
 -  Please follow __@zigo_101__ to get the latest news of **// Golds //**
    (and all kinds of Go details/facts/tips/etc.).
 

--- a/pages/bugs/string-builders-as-iteration-variables-in-traditional-for-loops-are-bad-implemented.html
+++ b/pages/bugs/string-builders-as-iteration-variables-in-traditional-for-loops-are-bad-implemented.html
@@ -80,7 +80,7 @@ The behaviors of the <code class="tmd-code-span">foo</code> and <code class="tmd
 </div>
 <p></p>
 <div class="tmd-usual">
-Nite: the <code class="tmd-code-span">go vet</code> command provided in Go toolchain 1.22 and 1.23 versions failed to warn on such cases.
+Note: the <code class="tmd-code-span">go vet</code> command provided in Go toolchain 1.22 and 1.23 versions failed to warn on such cases.
 </div>
 <p></p>
 <div class="tmd-usual">

--- a/pages/fundamentals/control-flows.html
+++ b/pages/fundamentals/control-flows.html
@@ -334,7 +334,7 @@ Use <code class="tmd-code-span">for-range</code> Control Flow Blocks to Iterate 
 </h3>
 <p></p>
 <div class="tmd-usual">
-<code class="tmd-code-span">for-range</code> loop blocks can be used to iterate integers, all kinds of <a href="container.html#iteration">containers</a>, <a href="channel.html#rang">channels</a>, and <a href="function.html#range">some functions</a>.. The current article only explains how to use <code class="tmd-code-span">for-range</code> loop blocks to iterate integers.
+<code class="tmd-code-span">for-range</code> loop blocks can be used to iterate integers, all kinds of <a href="container.html#iteration">containers</a>, <a href="channel.html#range">channels</a>, and <a href="function.html#range">some functions</a>.. The current article only explains how to use <code class="tmd-code-span">for-range</code> loop blocks to iterate integers.
 </div>
 <p></p>
 <p></p>

--- a/pages/fundamentals/quizzes.tmd
+++ b/pages/fundamentals/quizzes.tmd
@@ -4,7 +4,7 @@ The page has been moved to __/quizzes/101.html`` https://go101.org/quizzes/101.h
 <!--
 ### Go Quizzes 101
 
-Learn Go facts and details by participating in some quizzes (Twitter polls temporarily.
+Learn Go facts and details by participating in some quizzes (X polls temporarily.
 Please note that the most chosen answers are very possible not the correct ones.
 You should run each quiz program to get the correct answer.
 More interactive elements will be added to this page to enrich the user experience.

--- a/pages/fundamentals/value-part.html
+++ b/pages/fundamentals/value-part.html
@@ -142,7 +142,7 @@ If a value <code class="tmd-code-span">x</code> references (either directly or i
 Below, we call a struct type with fields of pointer types as a <span class="tmd-bold">pointer wrapper type</span>, and call a type whose values may contains (either directly or indirectly) pointers a <span class="tmd-bold">pointer holder type</span>. Pointer types and pointer wrapper types are all pointer holder types. Array types with  pointer holder element types are also pointer holder types. (Array types will be explained in the next article.)
 </div>
 <p></p>
-<h3 class="tmd-header-3">
+<h3 id="internal-definitions" class="tmd-header-3">
 (Possible) Internal Definitions of the Types in the Second Category
 </h3>
 <p></p>

--- a/pages/quizzes/101.html
+++ b/pages/quizzes/101.html
@@ -45,7 +45,7 @@ Each quiz will be answered in detail after the choices are made.
 	</div>
 </div>
 <p></p>
-<h3 class="tmd-header-3">
+<h3 id="index" class="tmd-header-3">
 Quizzes:
 </h3>
 <p></p>


### PR DESCRIPTION
This PR adds some missed changes that are left from 7cb3fbadb3baac7e1c697750594002e527f07712, e01f244dfc1ad6e186289ea8c6e76b356f94a4d6, and #299.

I spotted this when running `go run . -gen` locally.