### PR TITLE
Fix dead link in generics update page

### DIFF
--- a/pages/generics/100-updates.html
+++ b/pages/generics/100-updates.html
@@ -59,7 +59,7 @@ v1.20.a (2023/Feb/01)
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-add <a href="555-type-constraints-and-parameters.html#strictly-comparable">comparable vs. strictly comparable</a> and <a href="555-type-constraints-and-parameters.html#implementation-vs-satisfaction">type implementation vs. type satisfaction</a> sections in the <a href="(555-type-constraints-and-parameters.html">constraints and type parameters</a> chapter.
+add <a href="555-type-constraints-and-parameters.html#strictly-comparable">comparable vs. strictly comparable</a> and <a href="555-type-constraints-and-parameters.html#implementation-vs-satisfaction">type implementation vs. type satisfaction</a> sections in the <a href="555-type-constraints-and-parameters.html">constraints and type parameters</a> chapter.
 </div>
 </li>
 </ul>

--- a/pages/generics/100-updates.tmd
+++ b/pages/generics/100-updates.tmd
@@ -22,7 +22,7 @@
 
 * add __ comparable vs. strictly comparable`` 555-type-constraints-and-parameters.html#strictly-comparable__ and
   __ type implementation vs. type satisfaction`` 555-type-constraints-and-parameters.html#implementation-vs-satisfaction__ sections in the
-  __ constraints and type parameters`` (555-type-constraints-and-parameters.html__ chapter.
+  __ constraints and type parameters`` 555-type-constraints-and-parameters.html__ chapter.
 
 ###+++++ v1.19 (2022/Aug/29)
 


### PR DESCRIPTION
This PR fixes the link to "constraints and type parameters" on the page https://go101.org/generics/100-updates.html:

<img width="900" height="242" alt="image" src="https://github.com/user-attachments/assets/10762494-af9a-40dc-90a2-4d214784b079" />

The link to `https://go101.org/generics/(555-type-constraints-and-parameters.html` is broken because of redundant `(`.