### PR TITLE
Add go-get for go101-quiz-tmd-addon package

### DIFF
--- a/go-get.go
+++ b/go-get.go
@@ -72,6 +72,11 @@ var gogetInfos = map[string]GoGetInfo{
 		GoGetSourceRepo: "go101/godev",
 		GoDocWebsite:    "https://pkg.go.dev/",
 	},
+	"go101-quiz-tmd-addon": {
+		RootPackage:     "go101.org/go101-quiz-tmd-addon",
+		GoGetSourceRepo: "go101/go101-quiz-tmd-addon",
+		GoDocWebsite:    "https://pkg.go.dev/",
+	},
 }
 
 func (go101 *Go101) ServeGoGetPages(w http.ResponseWriter, r *http.Request, rootPkg, subPkg string) {


### PR DESCRIPTION
It's needed to be able to install [go101-quiz-tmd-addon](https://github.com/go101/go101-quiz-tmd-addon):

```
go install go101.org/go101-quiz-tmd-addon@latest
```