### PR TITLE
Fix typos in Fundamentals pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <b>[Go 101](https://go101.org)</b> is a series of books on Go programming.
-Currently, the following books are avaliable:
+Currently, the following books are available:
 
 * [Go (Fundamentals) 101](https://go101.org/article/101.html), which focuses on Go syntax/semantics (except custom generics related) and all kinds of runtime related things.
 * [Go Generics 101](https://go101.org/generics/101.html), which explains Go custom generics in detail.

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 var portFlag = flag.String("port", "55555", "server port")
 var genFlag = flag.Bool("gen", false, "HTML generation mode?")
 var themeFlag = flag.String("theme", "", "theme (dark | light)")
-var nobFlag = flag.Bool("nob", false, "not open browswer?")
+var nobFlag = flag.Bool("nob", false, "not open browser?")
 
 var listenConfig net.ListenConfig
 

--- a/pages/fundamentals/100-updates.html
+++ b/pages/fundamentals/100-updates.html
@@ -261,7 +261,7 @@ fix a bug in the example code in the <a href="container.html#delete-slice-elemen
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-correct explainations in <a href="function.html#function-evaluation-time">The Evaluation Moment of Deferred Function Values</a>.
+correct explanations in <a href="function.html#function-evaluation-time">The Evaluation Moment of Deferred Function Values</a>.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -353,7 +353,7 @@ add two situations in the article <a href="channel-closing.html">How to Graceful
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-<a href="type-system-overview.html#unnamed-type">the "named type" and "unnamed type" terminologies</a> are added back, but they are eqivalent to "defined type" and "non-defined type" now.
+<a href="type-system-overview.html#unnamed-type">the "named type" and "unnamed type" terminologies</a> are added back, but they are equivalent to "defined type" and "non-defined type" now.
 </div>
 </li>
 </ul>
@@ -382,7 +382,7 @@ remove the "named type" and "unnamed type" terminology.
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-adjust some discriptions in <a href="type-embedding.html">Type Embdding</a>.
+adjust some descriptions in <a href="type-embedding.html">Type Embedding</a>.
 </div>
 </li>
 </ul>
@@ -576,7 +576,7 @@ published <a href="acknowledgements.html">Acknowledgments</a>.
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-published <a href="reflection.html">Relections in Go</a>.
+published <a href="reflection.html">Reflections in Go</a>.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -605,7 +605,7 @@ added a new detail: <a href="details.html#os-exit-runtime-goexit">Exit a program
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-added a new detail: <a href="details.html#non-exported-names-from-different-packages">Non-exported method names and struct field names from different packages are viewed as diffferent names.</a>.
+added a new detail: <a href="details.html#non-exported-names-from-different-packages">Non-exported method names and struct field names from different packages are viewed as different names.</a>.
 </div>
 </li>
 <li class="tmd-list-item">

--- a/pages/fundamentals/100-updates.tmd
+++ b/pages/fundamentals/100-updates.tmd
@@ -80,7 +80,7 @@
 
 * fix a bug in the example code in the __ Delete a segment of slice elements`` container.html#delete-slice-elements__ section
   of the "Arrays, Slices and Maps in Go" article.
-* correct explainations in __ The Evaluation Moment of Deferred Function Values`` function.html#function-evaluation-time__.
+* correct explanations in __ The Evaluation Moment of Deferred Function Values`` function.html#function-evaluation-time__.
 * the article "The Right Places to Call the Built-in `recover` Function" is __ renamed to`` panic-and-recover-more.html__ "Explain Panic/Recover Mechanism in Detail". It was almost wholly re-written.
 
 ###+++++ 1.13.h (2019/Oct/18)
@@ -111,7 +111,7 @@
 * Go 1.13 ready.
 * add two situations in the article __ How to Gracefully Close Channels`` channel-closing.html__.
 * __ the "named type" and "unnamed type" terminologies`` type-system-overview.html#unnamed-type__ are added back,
-  but they are eqivalent to "defined type" and "non-defined type" now.
+  but they are equivalent to "defined type" and "non-defined type" now.
 
 ###+++++ 1.12.d (2019/May/18)
 
@@ -120,7 +120,7 @@
 ###+++++ 1.12.c (2019/April/09)
 
 * remove the "named type" and "unnamed type" terminology.
-* adjust some discriptions in __ Type Embdding`` type-embedding.html__.
+* adjust some descriptions in __ Type Embedding`` type-embedding.html__.
 
 ###+++++ 1.12.b (2019/April/06)
 
@@ -181,7 +181,7 @@
 
 ###+++++ 1.10.f (2018/May/15)
 
-* published __ Relections in Go`` reflection.html__.
+* published __ Reflections in Go`` reflection.html__.
 * added a channel use case: __ rate limiting`` channel-use-cases.html#rate-limiting__.
 
 
@@ -191,7 +191,7 @@
 
 ###+++++ 1.10.d (2018/Apr/18)
 
-* added a new detail: __ Non-exported method names and struct field names from different packages are viewed as diffferent names.`` details.html#non-exported-names-from-different-packages__.
+* added a new detail: __ Non-exported method names and struct field names from different packages are viewed as different names.`` details.html#non-exported-names-from-different-packages__.
 * added a FAQ question: __ What does the compiler error message `declared and not used` mean?`` unofficial-faq.html#error-declared-not-used__
 * added a FAQ question: __ What is the difference between the function call `time.Sleep(d)` and the channel receive operation `<-time.After(d)`?`` unofficial-faq.html#time-sleep-after__
 * added a FAQ question: __ What is the difference between the random numbers produced by the `math/rand` standard package and the `crypto/rand` standard package?`` unofficial-faq.html#math-crypto-rand__

--- a/pages/fundamentals/acknowledgements.html
+++ b/pages/fundamentals/acknowledgements.html
@@ -37,7 +37,7 @@ I'm sorry if I forgot mentioning somebody in above lists. There are so many kind
 </div>
 <p></p>
 <div class="tmd-usual">
-Thanks to the authors of the <a href="https://getbootstrap.com/docs/3.3/">Bootstrap framework</a>, <a href="https://jquery.com">jQuery library</a>, <a href="https://github.com/google/code-prettify">code prettify</a> and <a href="https://prismjs.com/">prism syntax highlighting</a> JavaSript packages, for supporting the go101.org website. Thanks to the authors of the <a href="https://github.com/bmaupin/go-epub">go-epub</a> and <a href="https://calibre-ebook.com/">calibre</a> projects for building Go 101 ebooks.
+Thanks to the authors of the <a href="https://getbootstrap.com/docs/3.3/">Bootstrap framework</a>, <a href="https://jquery.com">jQuery library</a>, <a href="https://github.com/google/code-prettify">code prettify</a> and <a href="https://prismjs.com/">prism syntax highlighting</a> JavaScript packages, for supporting the go101.org website. Thanks to the authors of the <a href="https://github.com/bmaupin/go-epub">go-epub</a> and <a href="https://calibre-ebook.com/">calibre</a> projects for building Go 101 ebooks.
 </div>
 <p></p>
 <div class="tmd-usual">

--- a/pages/fundamentals/acknowledgements.tmd
+++ b/pages/fundamentals/acknowledgements.tmd
@@ -225,7 +225,7 @@ __Bootstrap framework`` https://getbootstrap.com/docs/3.3/__,
 __jQuery library`` https://jquery.com__,
 __code prettify`` https://github.com/google/code-prettify__ and
 __prism syntax highlighting`` https://prismjs.com/__
-JavaSript packages, for supporting the go101.org website.
+JavaScript packages, for supporting the go101.org website.
 Thanks to the authors of the
 __go-epub`` https://github.com/bmaupin/go-epub__ and
 __calibre`` https://calibre-ebook.com/__

--- a/pages/fundamentals/concurrent-common-mistakes.html
+++ b/pages/fundamentals/concurrent-common-mistakes.html
@@ -492,7 +492,7 @@ Note, the <code class="tmd-code-span">if</code> code block is used to discard/dr
 </div>
 <p></p>
 <div class="tmd-usual">
-Note: since Go 1.23, the <code class="tmd-code-span">Timer.Reset</code> method will aoutomatically discard/drain the potential stale timer notification. So the above code can be simplified as
+Note: since Go 1.23, the <code class="tmd-code-span">Timer.Reset</code> method will automatically discard/drain the potential stale timer notification. So the above code can be simplified as
 </div>
 <p></p>
 <pre class="tmd-code line-numbers">

--- a/pages/fundamentals/concurrent-common-mistakes.tmd
+++ b/pages/fundamentals/concurrent-common-mistakes.tmd
@@ -521,7 +521,7 @@ Note, the `if` code block is used to discard/drain the potential timer notificat
 which is sent in the small period when executing the second branch code block
 (since Go 1.23, this has become needless).
 
-Note: since Go 1.23, the `Timer.Reset` method will aoutomatically discard/drain the potential stale timer notification.
+Note: since Go 1.23, the `Timer.Reset` method will automatically discard/drain the potential stale timer notification.
 So the above code can be simplified as
 
 @@@ .line-numbers

--- a/pages/fundamentals/container.html
+++ b/pages/fundamentals/container.html
@@ -1716,7 +1716,7 @@ func fb(buffers []Buffer) int {
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-Prior to Go 1.22, when a <code class="tmd-code-span">for-range</code> loop block (note the sign before before <code class="tmd-code-span">range</code> is <code class="tmd-code-span">:=</code>)
+Prior to Go 1.22, when a <code class="tmd-code-span">for-range</code> loop block (note the sign before <code class="tmd-code-span">range</code> is <code class="tmd-code-span">:=</code>)
 </div>
 <p></p>
 <pre class="tmd-code line-numbers">
@@ -1954,7 +1954,7 @@ The <code class="tmd-code-span">memclr</code> Optimization
 </h3>
 <p></p>
 <div class="tmd-usual">
-The Go standard Go compiler makes several optimizations so that it will convert loops with certain pattterns into internal <code class="tmd-code-span">memclr</code> calls. Before Go 1.21, we can make use of these optimizations to reset array/slice elements and clear map entries.
+The Go standard Go compiler makes several optimizations so that it will convert loops with certain patterns into internal <code class="tmd-code-span">memclr</code> calls. Before Go 1.21, we can make use of these optimizations to reset array/slice elements and clear map entries.
 </div>
 <p></p>
 <div class="tmd-usual">

--- a/pages/fundamentals/container.tmd
+++ b/pages/fundamentals/container.tmd
@@ -1744,7 +1744,7 @@ func fb(buffers []Buffer) int {
 '''
 
 Prior to Go 1.22, when a `for-range` loop block
-(note the sign before before `range` is `:=`)
+(note the sign before `range` is `:=`)
 
 @@@ .line-numbers
 ''' go
@@ -1979,7 +1979,7 @@ We can find that the `clear` function can even delete map entries with keys as `
 ###+++++++++++ The `memclr` Optimization
 
 The Go standard Go compiler makes several optimizations so that
-it will convert loops with certain pattterns into internal
+it will convert loops with certain patterns into internal
 `memclr` calls. Before Go 1.21, we can make use of these optimizations
 to reset array/slice elements and clear map entries.
 

--- a/pages/fundamentals/evaluation-orders.html
+++ b/pages/fundamentals/evaluation-orders.html
@@ -150,7 +150,7 @@ func (T) ab() []int { return []int{a, b} }
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-Please note that, Go specification doesn't compulsively specify the compilation order of the source files in a package, so try not to put some package-level variables into different source files in a package if there are complicate dependency relations between those variables; otherwise a variable might be initialzied to different values by different Go compilers.
+Please note that, Go specification doesn't compulsively specify the compilation order of the source files in a package, so try not to put some package-level variables into different source files in a package if there are complicate dependency relations between those variables; otherwise a variable might be initialized to different values by different Go compilers.
 </div>
 <p></p>
 <div class="tmd-usual">

--- a/pages/fundamentals/evaluation-orders.tmd
+++ b/pages/fundamentals/evaluation-orders.tmd
@@ -164,7 +164,7 @@ func (T) ab() []int { return []int{a, b} }
 Please note that, Go specification doesn't compulsively specify the compilation order of the source files
 in a package, so try not to put some package-level variables into different source files in a package
 if there are complicate dependency relations between those variables; otherwise a variable might be
-initialzied to different values by different Go compilers.
+initialized to different values by different Go compilers.
 
 And please be aware of that some Go Toolchain versions don't correctly implement
 the above rules described in the current section. For example:

--- a/pages/fundamentals/function.html
+++ b/pages/fundamentals/function.html
@@ -623,7 +623,7 @@ func main() {
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-For the specified cases shown the above example, the <code class="tmd-code-span">for-range</code> loops are eqivalent to the following function calls, respectively.
+For the specified cases shown the above example, the <code class="tmd-code-span">for-range</code> loops are equivalent to the following function calls, respectively.
 </div>
 <p></p>
 <pre class="tmd-code line-numbers">

--- a/pages/fundamentals/function.tmd
+++ b/pages/fundamentals/function.tmd
@@ -603,7 +603,7 @@ func main() {
 '''
 
 For the specified cases shown the above example,
-the `for-range` loops are eqivalent to the following function calls, respectively.
+the `for-range` loops are equivalent to the following function calls, respectively.
 
 @@@ .line-numbers
 ''' go

--- a/pages/fundamentals/memory-block.html
+++ b/pages/fundamentals/memory-block.html
@@ -127,7 +127,7 @@ Memory blocks can be allocated on stacks. Memory blocks allocated on the stack o
 </div>
 <p></p>
 <div class="tmd-usual">
-<span class="tmd-italic">(About which memory blocks will be allocated on stack, Please reand the "Stack and Escape Analysis" chapter in the </span><a href="https://go101.org/optimizations/101.html"><span class="tmd-italic">Go Optimizations 101</span></a><span class="tmd-italic"> book.)</span>
+<span class="tmd-italic">(About which memory blocks will be allocated on stack, Please read the "Stack and Escape Analysis" chapter in the </span><a href="https://go101.org/optimizations/101.html"><span class="tmd-italic">Go Optimizations 101</span></a><span class="tmd-italic"> book.)</span>
 </div>
 <p></p>
 <p></p>

--- a/pages/fundamentals/memory-block.tmd
+++ b/pages/fundamentals/memory-block.tmd
@@ -115,7 +115,7 @@ allocated on the stack of the goroutine
 without using any data synchronization techniques.
 
 //(About which memory blocks will be allocated on stack,
-Please reand the "Stack and Escape Analysis" chapter in the
+Please read the "Stack and Escape Analysis" chapter in the
 __Go Optimizations 101__ book.)
 
     === Go Optimizations 101 :: https://go101.org/optimizations/101.html

--- a/pages/fundamentals/method.html
+++ b/pages/fundamentals/method.html
@@ -94,7 +94,7 @@ func (age *Age) Increase() {
 
 // Receiver of custom defined function type.
 type FilterFunc func(in int) bool
-func (ff FilterFunc) Filte(in int) bool {
+func (ff FilterFunc) Filter(in int) bool {
 	return ff(in)
 }
 

--- a/pages/fundamentals/method.tmd
+++ b/pages/fundamentals/method.tmd
@@ -70,7 +70,7 @@ func (age *Age) Increase() {
 
 // Receiver of custom defined function type.
 type FilterFunc func(in int) bool
-func (ff FilterFunc) Filte(in int) bool {
+func (ff FilterFunc) Filter(in int) bool {
 	return ff(in)
 }
 

--- a/pages/fundamentals/panic-and-recover-more-newer.html
+++ b/pages/fundamentals/panic-and-recover-more-newer.html
@@ -184,7 +184,7 @@ That says,
 
 <p>
 So, when a goroutine finishes to exit, there may be at most one unrecovered panic in the goroutine.
-If a goroutine exits with an unrecovered panic and the unreovered panic is not a Goexit panic,
+If a goroutine exits with an unrecovered panic and the unrecovered panic is not a Goexit panic,
 the whole program crashes, and the information of the unrecovered panic will be reported.
 Otherwise, the goroutine exits normally (peacefully).
 This is why we say Goexit panics are harmless.

--- a/pages/fundamentals/panic-and-recover-more-newer.tmd
+++ b/pages/fundamentals/panic-and-recover-more-newer.tmd
@@ -184,7 +184,7 @@ That says,
 
 <p>
 So, when a goroutine finishes to exit, there may be at most one unrecovered panic in the goroutine.
-If a goroutine exits with an unrecovered panic and the unreovered panic is not a Goexit panic,
+If a goroutine exits with an unrecovered panic and the unrecovered panic is not a Goexit panic,
 the whole program crashes, and the information of the unrecovered panic will be reported.
 Otherwise, the goroutine exits normally (peacefully).
 This is why we say Goexit panics are harmless.

--- a/pages/fundamentals/panic-and-recover-use-cases.html
+++ b/pages/fundamentals/panic-and-recover-use-cases.html
@@ -244,7 +244,7 @@ However, usually, this panic/recover use pattern is not recommended to use. It i
 </div>
 <p></p>
 <div class="tmd-usual">
-And please note that, since Go 1.21, a <code class="tmd-code-span">panic(nil)</code> call will become <a href="https://github.com/golang/go/issues/25448">eqivalent to <code class="tmd-code-span">panic(new(runtime.PanicNilError))</code></a>. So since Go 1.21, the above deferred function call should be written as
+And please note that, since Go 1.21, a <code class="tmd-code-span">panic(nil)</code> call will become <a href="https://github.com/golang/go/issues/25448">equivalent to <code class="tmd-code-span">panic(new(runtime.PanicNilError))</code></a>. So since Go 1.21, the above deferred function call should be written as
 </div>
 <p></p>
 <pre class="tmd-code line-numbers">

--- a/pages/fundamentals/panic-and-recover-use-cases.tmd
+++ b/pages/fundamentals/panic-and-recover-use-cases.tmd
@@ -235,7 +235,7 @@ However, usually, this panic/recover use pattern is not recommended to use.
 It is less Go-idiomatic and less efficient.
 
 And please note that, since Go 1.21, a `panic(nil)` call will become
-__eqivalent to `panic(new(runtime.PanicNilError))`__.
+__equivalent to `panic(new(runtime.PanicNilError))`__.
 So since Go 1.21, the above deferred function call should be written as
 
 @@@ .line-numbers
@@ -256,7 +256,7 @@ func doSomething() (err error) {
 }
 '''
 
-    === eqivalent to ... :: https://github.com/golang/go/issues/25448
+    === equivalent to ... :: https://github.com/golang/go/issues/25448
 
 
 

--- a/pages/fundamentals/type-embedding.html
+++ b/pages/fundamentals/type-embedding.html
@@ -119,7 +119,7 @@ AliasPP          // base type is a pointer type
 *AliasPtr        // base type is a pointer type
 IntPtr           // named pointer type
 *IntPtr          // base type is a pointer type
-*chan int        // base type is an unmaed type
+*chan int        // base type is an unnamed type
 struct {age int} // unnamed non-pointer type
 map[string]int   // unnamed non-pointer type
 []int64          // unnamed non-pointer type

--- a/pages/fundamentals/type-embedding.tmd
+++ b/pages/fundamentals/type-embedding.tmd
@@ -142,7 +142,7 @@ AliasPP          // base type is a pointer type
 *AliasPtr        // base type is a pointer type
 IntPtr           // named pointer type
 *IntPtr          // base type is a pointer type
-*chan int        // base type is an unmaed type
+*chan int        // base type is an unnamed type
 struct {age int} // unnamed non-pointer type
 map[string]int   // unnamed non-pointer type
 []int64          // unnamed non-pointer type


### PR DESCRIPTION
Grammar mistakes in the `pages/fundamentals` directory.

Updates #241