### PR TITLE
Fix typos in Blog and Bugs pages

### DIFF
--- a/pages/blog/2022-08-22-some-undocumented-changes-in-go-1.18-and-1.19.html
+++ b/pages/blog/2022-08-22-some-undocumented-changes-in-go-1.18-and-1.19.html
@@ -408,7 +408,7 @@ There are also some undocumented small compiler and runtime optimizations made i
 <ol class="tmd-list tmd-footnotes" id="fn:">
 <li id="fn:gotv" class="tmd-list-item tmd-footnote-item">
 <div id="gotv" class="tmd-usual">
-GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain verisons harmoniously.
+GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain versions harmoniously.
 </div>
 <a href="#fn:gotv:ref-1">↩︎</a></li>
 </ol>

--- a/pages/blog/2022-08-22-some-undocumented-changes-in-go-1.18-and-1.19.tmd
+++ b/pages/blog/2022-08-22-some-undocumented-changes-in-go-1.18-and-1.19.tmd
@@ -318,5 +318,5 @@ Some of the small optimizations are mentioned in the __Go Optimizations 101__ bo
 { %%
 @@@ #gotv
 GoTV (__https://go101.org/apps-and-libs/gotv.html__) is a tool used to install and use coexisting installations
-of Go toolchain verisons harmoniously.  
+of Go toolchain versions harmoniously.  
 }

--- a/pages/blog/2022-11-18-constant-string-elements-are-not-constants.html
+++ b/pages/blog/2022-11-18-constant-string-elements-are-not-constants.html
@@ -41,7 +41,7 @@ func main() {
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-But if elements of constant strings become into constants, then the program will not compile, because the type of <code class="tmd-code-span">-S[0]</code> is <code class="tmd-code-span">byte</code> (aka. <code class="tmd-code-span">uint8</code>), whereas <code class="tmd-code-span">-71</code> owerflows the range of <code class="tmd-code-span">byte</code>.
+But if elements of constant strings become into constants, then the program will not compile, because the type of <code class="tmd-code-span">-S[0]</code> is <code class="tmd-code-span">byte</code> (aka. <code class="tmd-code-span">uint8</code>), whereas <code class="tmd-code-span">-71</code> overflows the range of <code class="tmd-code-span">byte</code>.
 </div>
 <p></p>
 <div class="tmd-usual">

--- a/pages/blog/2022-11-18-constant-string-elements-are-not-constants.tmd
+++ b/pages/blog/2022-11-18-constant-string-elements-are-not-constants.tmd
@@ -35,7 +35,7 @@ func main() {
 '''
 
 But if elements of constant strings become into constants, then the program will not compile,
-because the type of `-S[0]` is `byte` (aka. `uint8`), whereas `-71` owerflows the range of `byte`.
+because the type of `-S[0]` is `byte` (aka. `uint8`), whereas `-71` overflows the range of `byte`.
 
 It is a pity, it is also a luck.
 

--- a/pages/blog/2022-12-30-go-builtin-slice-manipulations-are-incomplete.html
+++ b/pages/blog/2022-12-30-go-builtin-slice-manipulations-are-incomplete.html
@@ -117,7 +117,7 @@ We can use the <code class="tmd-code-span">Clip</code> function in the <code cla
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-I do perfer <a href="https://github.com/golang/go/issues/25638">this proposal</a>, but it has been rejected:
+I do prefer <a href="https://github.com/golang/go/issues/25638">this proposal</a>, but it has been rejected:
 </div>
 <p></p>
 <pre class="tmd-code">

--- a/pages/blog/2022-12-30-go-builtin-slice-manipulations-are-incomplete.tmd
+++ b/pages/blog/2022-12-30-go-builtin-slice-manipulations-are-incomplete.tmd
@@ -104,7 +104,7 @@ import "golang.org/x/exp/slices"
 	... = append(slices.Clip(aFunctionCall()), x, y, z)
 '''
 
-I do perfer __this proposal__, but it has been rejected:
+I do prefer __this proposal__, but it has been rejected:
 
 ''' Go
 aSlice[ : n : ]  // <=> aSlice[ : n : n]

--- a/pages/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
+++ b/pages/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.html
@@ -247,7 +247,7 @@ Each iteration has its own separate declared variable (or variables). The variab
 <p></p>
 <p></p>
 <div class="tmd-usual">
-By the speficication, since Go 1.22, the loop shown above is actually equivalent to the following pseudo-code (<span class="tmd-italic">Sorry, the new semantics are hard to explain in a clear and perfect way. None of Go official documentations ever successfully achieve this goal. Here, I have tried my best.</span>):
+By the specification, since Go 1.22, the loop shown above is actually equivalent to the following pseudo-code (<span class="tmd-italic">Sorry, the new semantics are hard to explain in a clear and perfect way. None of Go official documentations ever successfully achieve this goal. Here, I have tried my best.</span>):
 </div>
 <p></p>
 <pre class="tmd-code">
@@ -951,7 +951,7 @@ Firstly, let's view a simple program.
 </div>
 <p></p>
 <pre class="tmd-code">
-<code class="language-Go">// demo-concurency1.go
+<code class="language-Go">// demo-concurrency1.go
 package main
 
 import (
@@ -976,8 +976,8 @@ func main() {
 The above program is intended to print the values of the loop variable <code class="tmd-code-span">i</code> at each iteration. Prior to Go 1.22, there is a clear data race condition present in the program, because the loop variable <code class="tmd-code-span">i</code> is only instantiated once during the whole loop. All the new created goroutines will read the single instance but the main goroutine will modify it. The following outputs prove this fact:
 </div>
 <pre class="tmd-code">
-$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurency1.go
-[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurency1.go
+$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurrency1.go
+[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurrency1.go
 3
 3
 ==================
@@ -991,8 +991,8 @@ WARNING: DATA RACE
 Prior to Go 1.22, the fix is simple, just add an <code class="tmd-code-span">i := i</code> line at the start of the loop body. Go 1.22 fixes the specified data race problem by changing the semantics of <code class="tmd-code-span">for;;</code> loops, without modifying the old problematic code. This can be verified by the following outputs:
 </div>
 <pre class="tmd-code">
-$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurency1.go
-[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurency1.go
+$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurrency1.go
+[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurrency1.go
 1
 2
 0
@@ -1007,7 +1007,7 @@ The effect of the attempt to fix the problem by making semantic change is actual
 </div>
 <p></p>
 <pre class="tmd-code">
-<code class="language-Go">// demo-concurency2.go
+<code class="language-Go">// demo-concurrency2.go
 package main
 
 import (
@@ -1037,8 +1037,8 @@ Is the new code still data race free (with Go 1.22 semantics)? It looks good. Ea
 The following outputs verify there is a data race condition present in the new code:
 </div>
 <pre class="tmd-code">
-$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurency2.go
-[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurency2.go
+$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurrency2.go
+[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurrency2.go
 ==================
 WARNING: DATA RACE
 ...
@@ -1062,7 +1062,7 @@ More seriously, some old good concurrent code will become problematic. Here is a
 </div>
 <p></p>
 <pre class="tmd-code">
-<code class="language-Go">// demo-concurency3.go
+<code class="language-Go">// demo-concurrency3.go
 package main
 
 import (
@@ -1104,15 +1104,15 @@ func main() {
 Run it with different toolchain versions, get the following outputs:
 </div>
 <pre class="tmd-code">
-$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurency3.go
-[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurency3.go
+$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurrency3.go
+[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurrency3.go
 Found gold 1048576
 Found gold 2097152
 Found gold 3145728
 ...
 ^C
-$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurency3.go
-[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurency3.go
+$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurrency3.go
+[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurrency3.go
 ==================
 WARNING: DATA RACE
 ...
@@ -1353,7 +1353,7 @@ What's done is done. In the end, I hope this article will help you write profess
 <ol class="tmd-list tmd-footnotes" id="fn:">
 <li id="fn:gotv" class="tmd-list-item tmd-footnote-item">
 <div id="gotv" class="tmd-usual">
-GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain verisons harmoniously.
+GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain versions harmoniously.
 </div>
 <a href="#fn:gotv:ref-1">↩︎</a></li>
 </ol>

--- a/pages/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.tmd
+++ b/pages/blog/2024-03-01-for-loop-semantic-changes-in-go-1.22.tmd
@@ -213,7 +213,7 @@ code to do the job. This is true. __Go 1.22+ specification__ says:
 
     === ... specification``https://go.dev/ref/spec#For_statements
 
-By the speficication, since Go 1.22, the loop shown above is
+By the specification, since Go 1.22, the loop shown above is
 actually equivalent to the following pseudo-code (//Sorry,
 the new semantics are hard to explain in a clear and perfect way.
 None of Go official documentations ever successfully achieve this goal.
@@ -884,7 +884,7 @@ Suggestions to avoid such performance degradation issue:
 Firstly, let's view a simple program.
 
 ''' Go
-// demo-concurency1.go
+// demo-concurrency1.go
 package main
 
 import (
@@ -911,8 +911,8 @@ because the loop variable `i` is only instantiated once during the whole loop.
 All the new created goroutines will read the single instance but the main goroutine
 will modify it. The following outputs prove this fact:
 '''
-$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurency1.go
-[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurency1.go
+$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurrency1.go
+[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurrency1.go
 3
 3
 ==================
@@ -926,8 +926,8 @@ Prior to Go 1.22, the fix is simple, just add an `i := i` line at the start of t
 Go 1.22 fixes the specified data race problem by changing the semantics of `for;;` loops,
 without modifying the old problematic code. This can be verified by the following outputs:
 '''
-$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurency1.go
-[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurency1.go
+$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurrency1.go
+[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurrency1.go
 1
 2
 0
@@ -940,7 +940,7 @@ The effect of the attempt to fix the problem by making semantic change is actual
 Let's modify the above program a bit:
 
 ''' Go
-// demo-concurency2.go
+// demo-concurrency2.go
 package main
 
 import (
@@ -972,8 +972,8 @@ however the instance is modified in a new created goroutine.
 
 The following outputs verify there is a data race condition present in the new code:
 '''
-$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurency2.go
-[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurency2.go
+$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurrency2.go
+[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurrency2.go
 ==================
 WARNING: DATA RACE
 ...
@@ -998,7 +998,7 @@ More seriously, some old good concurrent code will become problematic.
 Here is an example:
 
 ''' Go
-// demo-concurency3.go
+// demo-concurrency3.go
 package main
 
 import (
@@ -1038,15 +1038,15 @@ func main() {
 
 Run it with different toolchain versions, get the following outputs:
 '''
-$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurency3.go
-[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurency3.go
+$ CGO_ENABLED=1 gotv 1.21. run -race demo-concurrency3.go
+[Run]: $HOME/.cache/gotv/tag_go1.21.7/bin/go run -race demo-concurrency3.go
 Found gold 1048576
 Found gold 2097152
 Found gold 3145728
 ...
 ^C
-$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurency3.go
-[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurency3.go
+$ CGO_ENABLED=1 gotv 1.22. run -race demo-concurrency3.go
+[Run]: $HOME/.cache/gotv/tag_go1.22.0/bin/go run -race demo-concurrency3.go
 ==================
 WARNING: DATA RACE
 ...
@@ -1253,5 +1253,5 @@ professional Go code and use Go libraries correctly in the Go 1.22+ era.
 { %%
 @@@ #gotv
 GoTV (__https://go101.org/apps-and-libs/gotv.html__) is a tool used to install and use coexisting installations
-of Go toolchain verisons harmoniously.  
+of Go toolchain versions harmoniously.  
 }

--- a/pages/blog/2025-03-15-some-facts-about-iterators.html
+++ b/pages/blog/2025-03-15-some-facts-about-iterators.html
@@ -26,7 +26,7 @@ A simple introduction of Go iterators
 <p></p>
 <p></p>
 <div class="tmd-usual">
-Go 1.23 inroduced <a href="https://go.dev/blog/range-functions">iterators</a>, Iteators in Go are some functions which can be ranged over. Specifically, function expressions of types whose underlying types are in the following forms can be ranged over.
+Go 1.23 introduced <a href="https://go.dev/blog/range-functions">iterators</a>, Iterators in Go are some functions which can be ranged over. Specifically, function expressions of types whose underlying types are in the following forms can be ranged over.
 </div>
 <p></p>
 <pre class="tmd-code">
@@ -71,7 +71,7 @@ The function <code class="tmd-code-span">abc</code> is used as an iterator here.
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-Three arguments <code class="tmd-code-span">"a"</code>, <code class="tmd-code-span">"b"</code> and <code class="tmd-code-span">"c"</code> are in turn passed to the <code class="tmd-code-span">string</code> paramter and are used as the values of (the instances of) the loop variable <code class="tmd-code-span">v</code>.
+Three arguments <code class="tmd-code-span">"a"</code>, <code class="tmd-code-span">"b"</code> and <code class="tmd-code-span">"c"</code> are in turn passed to the <code class="tmd-code-span">string</code> parameter and are used as the values of (the instances of) the loop variable <code class="tmd-code-span">v</code>.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -304,7 +304,7 @@ For the iterator function shown above:
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-the following two ways of using it are equvalent.
+the following two ways of using it are equivalent.
 </div>
 <p></p>
 <div class="tmd-tab">
@@ -346,7 +346,7 @@ However, for the following iterator function:
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-the following two ways of using it are not equvalent.
+the following two ways of using it are not equivalent.
 </div>
 <p></p>
 <div class="tmd-tab">

--- a/pages/blog/2025-03-15-some-facts-about-iterators.tmd
+++ b/pages/blog/2025-03-15-some-facts-about-iterators.tmd
@@ -9,8 +9,8 @@ Contents:
 
     === iterators :: https://go.dev/blog/range-functions
 
-Go 1.23 inroduced __iterators__,
-Iteators in Go are some functions which can be ranged over.
+Go 1.23 introduced __iterators__,
+Iterators in Go are some functions which can be ranged over.
 Specifically, function expressions of types whose underlying types
 are in the following forms can be ranged over.
 
@@ -53,7 +53,7 @@ The function `abc` is used as an iterator here.
 Its parameter `yield` is a callback function which takes a `string` parameter
 and returns a `bool` result.
 *  Three arguments `"a"`, `"b"` and `"c"` are in turn passed to
-   the `string` paramter and are used as
+   the `string` parameter and are used as
    the values of (the instances of) the loop variable `v`.
 *  The loop body can be basically viewed as the function body of the `yield` function.
    Just note that, if the execution of a loop step during ranging over
@@ -268,7 +268,7 @@ func abc(yield func(string) bool) {
 }
 '''
 
-the following two ways of using it are equvalent.
+the following two ways of using it are equivalent.
 
 *  ### Way 1
    ''' Go
@@ -294,7 +294,7 @@ func abcThenPanic(yield func(string) bool) {
 }
 '''
 
-the following two ways of using it are not equvalent.
+the following two ways of using it are not equivalent.
 
 *  ### Way 1
    ''' Go

--- a/pages/blog/2025-10-22-some-real-go-subtleties.html
+++ b/pages/blog/2025-10-22-some-real-go-subtleties.html
@@ -5,7 +5,7 @@ Some (Real) Go Subtleties
 </h1>
 <p></p>
 <div class="tmd-usual">
-I just read an article: <a href="https://harrisoncramer.me/15-go-sublteties-you-may-not-already-know/">15 Go Subtleties You May Not Already Know</a>. After reading that article, I just feel the title is some weird/improper. Because all the so-called subtleties mentioned in that article are what a quanlified Go programer should know about.
+I just read an article: <a href="https://harrisoncramer.me/15-go-sublteties-you-may-not-already-know/">15 Go Subtleties You May Not Already Know</a>. After reading that article, I just feel the title is some weird/improper. Because all the so-called subtleties mentioned in that article are what a qualified Go programmer should know about.
 </div>
 <p></p>
 <p></p>

--- a/pages/blog/2025-10-22-some-real-go-subtleties.tmd
+++ b/pages/blog/2025-10-22-some-real-go-subtleties.tmd
@@ -4,7 +4,7 @@
 I just read an article: __15 Go Subtleties You May Not Already Know__.
 After reading that article, I just feel the title is some weird/improper.
 Because all the so-called subtleties mentioned in that article
-are what a quanlified Go programer should know about.
+are what a qualified Go programmer should know about.
 
     === 15 Go Subtleties ... :: https://harrisoncramer.me/15-go-sublteties-you-may-not-already-know/
 

--- a/pages/bugs/a-switch-case-channel-comparison-bug.html
+++ b/pages/bugs/a-switch-case-channel-comparison-bug.html
@@ -5,7 +5,7 @@ A channel comparison bug when channels are used as <code class="tmd-code-span">c
 </h1>
 <p></p>
 <div class="tmd-usual">
-<span class="tmd-italic">(The releatd issue: </span><a href="https://github.com/golang/go/issues/67190"><span class="tmd-italic">https://github.com/golang/go/issues/67190</span></a><span class="tmd-italic">.)</span>
+<span class="tmd-italic">(The related issue: </span><a href="https://github.com/golang/go/issues/67190"><span class="tmd-italic">https://github.com/golang/go/issues/67190</span></a><span class="tmd-italic">.)</span>
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -73,7 +73,7 @@ If you are using a Go toolchain version between v1.20 and v1.23.0 (exclusive), y
 <ol class="tmd-list tmd-footnotes" id="fn:">
 <li id="fn:gotv" class="tmd-list-item tmd-footnote-item">
 <div id="gotv" class="tmd-usual">
-GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain verisons harmoniously.
+GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain versions harmoniously.
 </div>
 <a href="#fn:gotv:ref-1">↩︎</a></li>
 </ol>

--- a/pages/bugs/a-switch-case-channel-comparison-bug.tmd
+++ b/pages/bugs/a-switch-case-channel-comparison-bug.tmd
@@ -1,7 +1,7 @@
 
 ### A channel comparison bug when channels are used as `case` expressions of `switch` code blocks (in Go toolchain v1.20 - v1.23.x)
 
-// (The releatd issue: __https://github.com/golang/go/issues/67190__.)
+// (The related issue: __https://github.com/golang/go/issues/67190__.)
 
 In Go toolchain v1.20 - v1.23.x, there is a channel value comparison bug,
 which is demonstrated in the following program:
@@ -62,5 +62,5 @@ you should be aware of this bug.
 { %%
 @@@ #gotv
 GoTV (__https://go101.org/apps-and-libs/gotv.html__) is a tool used to install and use coexisting installations
-of Go toolchain verisons harmoniously.  
+of Go toolchain versions harmoniously.  
 }

--- a/pages/bugs/go-build-directive-not-work.html
+++ b/pages/bugs/go-build-directive-not-work.html
@@ -5,7 +5,7 @@ The <code class="tmd-code-span">//go:build go1.mn</code> comment directives don'
 </h1>
 <p></p>
 <div class="tmd-usual">
-Go 1.22 changed the semantics of <code class="tmd-code-span">for-range</code> and tranditional <code class="tmd-code-span">for;;</code> loops. Since the semantic changes alter the behavior of existing code written according to the previous semantics, they break backward compatibility.
+Go 1.22 changed the semantics of <code class="tmd-code-span">for-range</code> and transitional <code class="tmd-code-span">for;;</code> loops. Since the semantic changes alter the behavior of existing code written according to the previous semantics, they break backward compatibility.
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -23,7 +23,7 @@ While officially documented, due to <a href="https://github.com/golang/go/issues
 <p></p>
 <p></p>
 <div class="tmd-usual">
-Here, I simply describe this bug: for a Go source file which Go version is not specified in a <code class="tmd-code-span">go.mod</code> file, the <code class="tmd-code-span">//go:build go1.mn</code> comment directive in it fails to specify the Go verison for it.
+Here, I simply describe this bug: for a Go source file which Go version is not specified in a <code class="tmd-code-span">go.mod</code> file, the <code class="tmd-code-span">//go:build go1.mn</code> comment directive in it fails to specify the Go version for it.
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -89,7 +89,7 @@ The Go core team deliberately <a href="https://github.com/golang/go/issues/66092
 <ol class="tmd-list tmd-footnotes" id="fn:">
 <li id="fn:gotv" class="tmd-list-item tmd-footnote-item">
 <div id="gotv" class="tmd-usual">
-GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain verisons harmoniously.
+GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain versions harmoniously.
 </div>
 <a href="#fn:gotv:ref-1">↩︎</a></li>
 </ol>

--- a/pages/bugs/go-build-directive-not-work.tmd
+++ b/pages/bugs/go-build-directive-not-work.tmd
@@ -2,7 +2,7 @@
 ### The `//go:build go1.mn` comment directives don't work with Go toolchain v1.22.x versions
     when no `go.mod` files are involved
 
-Go 1.22 changed the semantics of `for-range` and tranditional `for;;` loops.
+Go 1.22 changed the semantics of `for-range` and transitional `for;;` loops.
 Since the semantic changes alter the behavior of existing code written according
 to the previous semantics, they break backward compatibility.
 
@@ -23,7 +23,7 @@ this way is currently non-functional with Go toolchain 1.22.x versions.
 
 Here, I simply describe this bug: for a Go source file which Go version
 is not specified in a `go.mod` file, the `//go:build go1.mn` comment directive
-in it fails to specify the Go verison for it.
+in it fails to specify the Go version for it.
 
 Here is an example:
 
@@ -89,5 +89,5 @@ in 1.22.x versions when you are using them to develop Go projects.
 { %%
 @@@ #gotv
 GoTV (__https://go101.org/apps-and-libs/gotv.html__) is a tool used to install and use coexisting installations
-of Go toolchain verisons harmoniously.  
+of Go toolchain versions harmoniously.  
 }

--- a/pages/bugs/recover-calls-in-loop-bodies-of-ranging-over-iterators-not-work.html
+++ b/pages/bugs/recover-calls-in-loop-bodies-of-ranging-over-iterators-not-work.html
@@ -51,7 +51,7 @@ func iter(yield func() bool) {
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-<span class="tmd-italic">(The releatd issue: </span><a href="https://github.com/golang/go/issues/71685"><span class="tmd-italic">https://github.com/golang/go/issues/71685</span></a><span class="tmd-italic">.)</span>
+<span class="tmd-italic">(The related issue: </span><a href="https://github.com/golang/go/issues/71685"><span class="tmd-italic">https://github.com/golang/go/issues/71685</span></a><span class="tmd-italic">.)</span>
 </div>
 <p></p>
 </div>

--- a/pages/bugs/recover-calls-in-loop-bodies-of-ranging-over-iterators-not-work.tmd
+++ b/pages/bugs/recover-calls-in-loop-bodies-of-ranging-over-iterators-not-work.tmd
@@ -44,5 +44,5 @@ func iter(yield func() bool) {
 }
 '''
 
-// (The releatd issue: __https://github.com/golang/go/issues/71685__.)
+// (The related issue: __https://github.com/golang/go/issues/71685__.)
 

--- a/pages/bugs/string-builders-as-iteration-variables-in-traditional-for-loops-are-bad-implemented.html
+++ b/pages/bugs/string-builders-as-iteration-variables-in-traditional-for-loops-are-bad-implemented.html
@@ -76,7 +76,7 @@ panic: strings: illegal use of non-zero Builder copied by value
 </pre>
 <p></p>
 <div class="tmd-usual">
-The behaviors of the <code class="tmd-code-span">foo</code> and <code class="tmd-code-span">bar</code> functions should be consistent with each other, but tthe official Go toolchain v1.22+ fail to make the guarantee. In fact, by the Go 1.22+ new semantics, both of the <code class="tmd-code-span">foo</code> and <code class="tmd-code-span">bar</code> functions should produce a panic, because nocopy values should not be used as (freshly declared) iteration variables since Go 1.22.
+The behaviors of the <code class="tmd-code-span">foo</code> and <code class="tmd-code-span">bar</code> functions should be consistent with each other, but the official Go toolchain v1.22+ fail to make the guarantee. In fact, by the Go 1.22+ new semantics, both of the <code class="tmd-code-span">foo</code> and <code class="tmd-code-span">bar</code> functions should produce a panic, because nocopy values should not be used as (freshly declared) iteration variables since Go 1.22.
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -94,7 +94,7 @@ The Go core team <a href="https://github.com/golang/go/issues/66070#issuecomment
 <ol class="tmd-list tmd-footnotes" id="fn:">
 <li id="fn:gotv" class="tmd-list-item tmd-footnote-item">
 <div id="gotv" class="tmd-usual">
-GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain verisons harmoniously.
+GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain versions harmoniously.
 </div>
 <a href="#fn:gotv:ref-1">↩︎</a></li>
 </ol>

--- a/pages/bugs/string-builders-as-iteration-variables-in-traditional-for-loops-are-bad-implemented.tmd
+++ b/pages/bugs/string-builders-as-iteration-variables-in-traditional-for-loops-are-bad-implemented.tmd
@@ -74,7 +74,7 @@ panic: strings: illegal use of non-zero Builder copied by value
 '''
 
 The behaviors of the `foo` and `bar` functions should be consistent with each other,
-but tthe official Go toolchain v1.22+ fail to make the guarantee.
+but the official Go toolchain v1.22+ fail to make the guarantee.
 In fact, by the Go 1.22+ new semantics, both of the `foo` and `bar`
 functions should produce a panic, because nocopy values should not
 be used as (freshly declared) iteration variables since Go 1.22.
@@ -91,5 +91,5 @@ The Go core team __refused to fix this bug__. You should be aware of this bug.
 { %%
 @@@ #gotv
 GoTV (__https://go101.org/apps-and-libs/gotv.html__) is a tool used to install and use coexisting installations
-of Go toolchain verisons harmoniously.  
+of Go toolchain versions harmoniously.  
 }


### PR DESCRIPTION
Grammar mistakes in the `pages/blog` and `pages/bugs` directories.

Updates #241