### PR TITLE
Fix typos in Quizzes and Q&A pages

### DIFF
--- a/pages/q-and-a/canonicalize-strings.html
+++ b/pages/q-and-a/canonicalize-strings.html
@@ -95,7 +95,7 @@ The way is more flexible. Just apply the above <code class="tmd-code-span">Canon
 <div class="tmd-callout">
 <div class="tmd-callout-content">
 <div class="tmd-usual">
-Note: the <code class="tmd-code-span">unique.Make</code> way is not always suitable for every situation. The <code class="tmd-code-span">unique.Make</code> function will allocate a backing bytes memory blcok for each distinct string. So if some unequal strings to be canonicalized share the same backing bytes memory block, the <code class="tmd-code-span">unique.Make</code> function will allocate a new backing byte sequence memory block for each of the strings. Doing this actually allocates more memory (than using a single memory block).
+Note: the <code class="tmd-code-span">unique.Make</code> way is not always suitable for every situation. The <code class="tmd-code-span">unique.Make</code> function will allocate a backing bytes memory block for each distinct string. So if some unequal strings to be canonicalized share the same backing bytes memory block, the <code class="tmd-code-span">unique.Make</code> function will allocate a new backing byte sequence memory block for each of the strings. Doing this actually allocates more memory (than using a single memory block).
 </div>
 </div>
 </div>

--- a/pages/q-and-a/canonicalize-strings.tmd
+++ b/pages/q-and-a/canonicalize-strings.tmd
@@ -80,7 +80,7 @@ underlying bytes memory blocks.
 
 !  Note: the `unique.Make` way is not always suitable for every situation.
    The `unique.Make` function will allocate a backing bytes
-   memory blcok for each distinct string.
+   memory block for each distinct string.
    So if some unequal strings to be canonicalized share the same
    backing bytes memory block, the `unique.Make` function will allocate
    a new backing byte sequence memory block for each of the strings.

--- a/pages/q-and-a/clone-slices.html
+++ b/pages/q-and-a/clone-slices.html
@@ -37,7 +37,7 @@ the capacity of the cloned slice is not aligned to a memory class size. <span cl
 </ul>
 <p></p>
 <div class="tmd-usual">
-For the two reasons, thw way is the fastest approach.
+For the two reasons, this way is the fastest approach.
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -79,7 +79,7 @@ Way 2: the more verbose form of way 1
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-Excpet for the first drawback of the way 1, the verbose way offers similar benefits and drawbacks to way 1.
+Except for the first drawback of the way 1, the verbose way offers similar benefits and drawbacks to way 1.
 </div>
 <p></p>
 <h3 class="tmd-header-3">
@@ -116,7 +116,7 @@ The drawbacks of this approach:
 <ol class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-For the two reasons, currently, thw way is the slowest way.
+For the two reasons, currently, this way is the slowest way.
 </div>
 </li>
 <li class="tmd-list-item">
@@ -167,7 +167,7 @@ The drawbacks of this approach:
 <ol class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-For the two reasons, thw way is slower than other ones.
+For the two reasons, this way is slower than other ones.
 </div>
 <ul class="tmd-list">
 <li class="tmd-list-item">

--- a/pages/q-and-a/clone-slices.tmd
+++ b/pages/q-and-a/clone-slices.tmd
@@ -18,7 +18,7 @@ Note:
    //(Memory class sizes are mentioned in __Go Optimizations 101__.)
        === Go Optimizations 101 `` https://go101.org/optimizations/0.3-memory-allocations.html
 
-For the two reasons, thw way is the fastest approach.
+For the two reasons, this way is the fastest approach.
 
 The drawbacks of this approach:
 *. If the source slice `aSlice` is nil, the cloned slice is not nil. Sometimes, this matters.
@@ -36,7 +36,7 @@ The drawbacks of this approach:
 	}
 '''
 
-Excpet for the first drawback of the way 1, the verbose way offers similar benefits and drawbacks to way 1.
+Except for the first drawback of the way 1, the verbose way offers similar benefits and drawbacks to way 1.
 
 ###++++++++ Way 3: use `make` and `append`
 
@@ -54,7 +54,7 @@ Note:
    //(Memory class sizes are mentioned in __Go Optimizations 101__.)
 
 The drawbacks of this approach:
-*. For the two reasons, currently, thw way is the slowest way.
+*. For the two reasons, currently, this way is the slowest way.
 *. If the source slice `aSlice` is nil, the cloned slice is not nil. Sometimes, this matters.
 *. It needs to import the containing package of type `SliceType` if `SliceType` is declared in another package.
 
@@ -75,7 +75,7 @@ Note:
    //(Memory class sizes are mentioned in __Go Optimizations 101__.)
 
 The drawbacks of this approach:
-*. For the two reasons, thw way is slower than other ones.
+*. For the two reasons, this way is slower than other ones.
    -  for manner 1, if the source slice `aSlice` is a non-nil blank slice, the cloned slice is nil.
    -  for manner 2, if the source slice `aSlice` is a nil slice, the cloned slice is not nil.
 *. It needs to import the containing package of type `SliceType` if `SliceType` is declared in another package.

--- a/pages/q-and-a/make-dirty-byte-slices.html
+++ b/pages/q-and-a/make-dirty-byte-slices.html
@@ -9,7 +9,7 @@ Prior to Go 1.21, there is no way to achieve this, even if with unsafe ways.
 </div>
 <p></p>
 <div class="tmd-usual">
-Since Go 1.21, the implmentation of <code class="tmd-code-span">strings.Builder.Grow</code> calls an internal <code class="tmd-code-span">bytealg.MakeNoZero</code> function instead of the built-in <code class="tmd-code-span">make</code> function the old implementation called. For most cases, the built-in <code class="tmd-code-span">make</code> function will zero the elements of the result slice, so it is often comparatively slower.
+Since Go 1.21, the implementation of <code class="tmd-code-span">strings.Builder.Grow</code> calls an internal <code class="tmd-code-span">bytealg.MakeNoZero</code> function instead of the built-in <code class="tmd-code-span">make</code> function the old implementation called. For most cases, the built-in <code class="tmd-code-span">make</code> function will zero the elements of the result slice, so it is often comparatively slower.
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -31,7 +31,7 @@ func MakeDirtyByteSlice(n int) []byte {
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-However, for an unknown reason (which should be releted to the official compiler/runtime implementation), benchmark results show that the function is not as faster as expected when the length of the created byte slice is not large.
+However, for an unknown reason (which should be related to the official compiler/runtime implementation), benchmark results show that the function is not as faster as expected when the length of the created byte slice is not large.
 </div>
 <p></p>
 <pre class="tmd-code">

--- a/pages/q-and-a/make-dirty-byte-slices.tmd
+++ b/pages/q-and-a/make-dirty-byte-slices.tmd
@@ -3,7 +3,7 @@
 
 Prior to Go 1.21, there is no way to achieve this, even if with unsafe ways.
 
-Since Go 1.21, the implmentation of `strings.Builder.Grow` calls an
+Since Go 1.21, the implementation of `strings.Builder.Grow` calls an
 internal `bytealg.MakeNoZero` function instead of the built-in `make`
 function the old implementation called.
 For most cases, the built-in `make` function will zero the elements
@@ -27,7 +27,7 @@ func MakeDirtyByteSlice(n int) []byte {
 }
 '''
 
-However, for an unknown reason (which should be releted to the official
+However, for an unknown reason (which should be related to the official
 compiler/runtime implementation), benchmark results show that
 the function is not as faster as expected
 when the length of the created byte slice is not large.

--- a/pages/q-and-a/take-string-byte-addresses.html
+++ b/pages/q-and-a/take-string-byte-addresses.html
@@ -136,7 +136,7 @@ true
 </pre>
 <p></p>
 <div class="tmd-usual">
-Wait! Does this mean we can modify string content now? Don't worry. The answer is certainly not. The compiler can successfully detect such attempts and disable the optimimation for the invloved conversions, as the following code demonstrates:
+Wait! Does this mean we can modify string content now? Don't worry. The answer is certainly not. The compiler can successfully detect such attempts and disable the optimization for the involved conversions, as the following code demonstrates:
 </div>
 <p></p>
 <pre class="tmd-code">
@@ -222,7 +222,7 @@ func CommonStringPrefix2(x, y string) int {
 <ol class="tmd-list tmd-footnotes" id="fn:">
 <li id="fn:gotv" class="tmd-list-item tmd-footnote-item">
 <div id="gotv" class="tmd-usual">
-GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain verisons harmoniously.
+GoTV (<a href="https://go101.org/apps-and-libs/gotv.html">https://go101.org/apps-and-libs/gotv.html</a>) is a tool used to install and use coexisting installations of Go toolchain versions harmoniously.
 </div>
 <a href="#fn:gotv:ref-1">↩︎</a><a href="#fn:gotv:ref-2">↩︎</a></li>
 </ol>

--- a/pages/q-and-a/take-string-byte-addresses.tmd
+++ b/pages/q-and-a/take-string-byte-addresses.tmd
@@ -124,7 +124,7 @@ true
 Wait! Does this mean we can modify string content now?
 Don't worry. The answer is certainly not.
 The compiler can successfully detect such attempts
-and disable the optimimation for the invloved conversions,
+and disable the optimization for the involved conversions,
 as the following code demonstrates:
 
 ''' Go
@@ -208,5 +208,5 @@ func CommonStringPrefix2(x, y string) int {
 { %%
 @@@ #gotv
 GoTV (__https://go101.org/apps-and-libs/gotv.html__) is a tool used to install and use coexisting installations
-of Go toolchain verisons harmoniously.  
+of Go toolchain versions harmoniously.  
 }

--- a/pages/quizzes/const-1.html
+++ b/pages/quizzes/const-1.html
@@ -65,7 +65,7 @@ Go spec says: <span class="tmd-italic">Within a parenthesized const declaration 
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-the value of the prededeclared <code class="tmd-code-span">iota</code> is the constant specification order id (0-based) in a constant declaration.
+the value of the predeclared <code class="tmd-code-span">iota</code> is the constant specification order id (0-based) in a constant declaration.
 </div>
 </li>
 </ul>

--- a/pages/quizzes/const-1.tmd
+++ b/pages/quizzes/const-1.tmd
@@ -45,7 +45,7 @@ Key points:
 	Go spec says: // Within a parenthesized const declaration list the expression list may be omitted from any but the first ConstSpec.
 	Such an empty list is equivalent to the textual substitution of the first preceding non-empty expression list and its type if any.
 * 
-	the value of the prededeclared `iota` is the constant specification order id (0-based) in a constant declaration.
+	the value of the predeclared `iota` is the constant specification order id (0-based) in a constant declaration.
 
 
 

--- a/pages/quizzes/const-2.html
+++ b/pages/quizzes/const-2.html
@@ -67,7 +67,7 @@ a local identifier will shadow the global identifier with the same name.
 </ul>
 <p></p>
 <div class="tmd-usual">
-The consntant declaration in the quiz code is equivalent to the following one:
+The constant declaration in the quiz code is equivalent to the following one:
 </div>
 <p></p>
 <pre class="tmd-code line-numbers">
@@ -78,7 +78,7 @@ The consntant declaration in the quiz code is equivalent to the following one:
 </code></pre>
 <p></p>
 <div class="tmd-usual">
-The local <code class="tmd-code-span">X</code> is evaluated as 6 at compile time, so the constant <code class="tmd-code-span">Y</code> is evaluaed as 12 (also at compile time).
+The local <code class="tmd-code-span">X</code> is evaluated as 6 at compile time, so the constant <code class="tmd-code-span">Y</code> is evaluated as 12 (also at compile time).
 </div>
 <p></p>
 <div class="tmd-usual">

--- a/pages/quizzes/const-2.tmd
+++ b/pages/quizzes/const-2.tmd
@@ -45,7 +45,7 @@ Key points:
 	a local identifier will shadow the global identifier with the same name.
 
 
-The consntant declaration in the quiz code is equivalent to the following one:
+The constant declaration in the quiz code is equivalent to the following one:
 
 @@@ .line-numbers
 ''' go
@@ -56,7 +56,7 @@ The consntant declaration in the quiz code is equivalent to the following one:
 '''
 
 The local `X` is evaluated as 6 at compile time,
-so the constant `Y` is evaluaed as 12 (also at compile time).
+so the constant `Y` is evaluated as 12 (also at compile time).
 
 Please note that, __ the output result was `6 6` when using Go toolchain v1.17-`` https://github.com/golang/go/issues __.
 The bug has been fixed since Go toochain v1.18.

--- a/pages/quizzes/const-4.html
+++ b/pages/quizzes/const-4.html
@@ -43,7 +43,7 @@ Choices:
 </div><p></p>
 <div id="answer" class="tmd-base">
 <div class="tmd-usual">
-Answer: it princs 1.
+Answer: it prints 1.
 </div>
 <p></p>
 <div class="tmd-usual">
@@ -56,7 +56,7 @@ Key points:
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-For a constant string <code class="tmd-code-span">S</code>, the expression <code class="tmd-code-span">S[i]</code> is always treated as a non-constant (please read the <a href="https://go101.org/article/string.html">stirngs in Go</a> article or <a href="https://go101.org/details-and-tips/101.html">Go Details and Tips</a> book). So the program compiles.
+For a constant string <code class="tmd-code-span">S</code>, the expression <code class="tmd-code-span">S[i]</code> is always treated as a non-constant (please read the <a href="https://go101.org/article/string.html">strings in Go</a> article or <a href="https://go101.org/details-and-tips/101.html">Go Details and Tips</a> book). So the program compiles.
 </div>
 </li>
 <li class="tmd-list-item">

--- a/pages/quizzes/const-4.tmd
+++ b/pages/quizzes/const-4.tmd
@@ -33,14 +33,14 @@ It fails to compile.
 
 @@@ #answer
 {
-Answer: it princs 1.
+Answer: it prints 1.
 
 Run it on __ Go play`` https://go.dev/play/p/ElskwAlPNxw __.
 
 Key points:
 * 
 	For a constant string `S`, the expression `S[i]` is always treated as a non-constant
-	(please read the __ stirngs in Go`` https://go101.org/article/string.html __ article or
+	(please read the __ strings in Go`` https://go101.org/article/string.html __ article or
 	__ Go Details and Tips`` https://go101.org/details-and-tips/101.html __ book).
 	So the program compiles.
 * 

--- a/pages/quizzes/const-iota-1.html
+++ b/pages/quizzes/const-iota-1.html
@@ -64,7 +64,7 @@ within a constant declaration, an omitted expression list in a constant specific
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-the value of the prededeclared <code class="tmd-code-span">iota</code> is the constant specification order id (0-based) in a constant declaration.
+the value of the predeclared <code class="tmd-code-span">iota</code> is the constant specification order id (0-based) in a constant declaration.
 </div>
 </li>
 </ul>

--- a/pages/quizzes/const-iota-1.tmd
+++ b/pages/quizzes/const-iota-1.tmd
@@ -42,7 +42,7 @@ Key points:
 * 
 	within a constant declaration, an omitted expression list in a constant specification is equivalent to repeating the list in the previous constant specification.
 * 
-	the value of the prededeclared `iota` is the constant specification order id (0-based) in a constant declaration.
+	the value of the predeclared `iota` is the constant specification order id (0-based) in a constant declaration.
 
 
 

--- a/pages/quizzes/operator-2.html
+++ b/pages/quizzes/operator-2.html
@@ -59,7 +59,7 @@ Key points:
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-In Go, for a <code class="tmd-code-span">byte</code> (a.k.a. <code class="tmd-code-span">uint8</code>) non-constant non-zero value <code class="tmd-code-span">x</code>, <code class="tmd-code-span">-x</code> overflows the range of type <code class="tmd-code-span">byte</code> and is wrarpped as <code class="tmd-code-span">(-x + 256) % 256</code>.
+In Go, for a <code class="tmd-code-span">byte</code> (a.k.a. <code class="tmd-code-span">uint8</code>) non-constant non-zero value <code class="tmd-code-span">x</code>, <code class="tmd-code-span">-x</code> overflows the range of type <code class="tmd-code-span">byte</code> and is wrapped as <code class="tmd-code-span">(-x + 256) % 256</code>.
 </div>
 </li>
 <li class="tmd-list-item">

--- a/pages/quizzes/operator-2.tmd
+++ b/pages/quizzes/operator-2.tmd
@@ -41,7 +41,7 @@ Run it on __ Go play`` https://go.dev/play/p/qbtozNmX-Pv __.
 Key points:
 * 
 	In Go, for a `byte` (a.k.a. `uint8`) non-constant non-zero value `x`,
-	`-x` overflows the range of type `byte` and is wrarpped as `(-x + 256) % 256`.
+	`-x` overflows the range of type `byte` and is wrapped as `(-x + 256) % 256`.
 * 
 	For a variable `x` of type `byte`, `x == -x` happens only when `x` is `0` or `128`.
 

--- a/pages/quizzes/scope-1.html
+++ b/pages/quizzes/scope-1.html
@@ -58,7 +58,7 @@ Key point:
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-The <code class="tmd-code-span">r</code> varialbe declared in the inner block is not a re-declaration of the one (the return result) declared in the function top block. It is totally a new declared variable. So the return result is not modified in the inner block.
+The <code class="tmd-code-span">r</code> variable declared in the inner block is not a re-declaration of the one (the return result) declared in the function top block. It is totally a new declared variable. So the return result is not modified in the inner block.
 </div>
 </li>
 </ul>

--- a/pages/quizzes/scope-1.tmd
+++ b/pages/quizzes/scope-1.tmd
@@ -40,7 +40,7 @@ Run it on __ Go play`` https://go.dev/play/p/YimtmACsxOP __.
 
 Key point:
 * 
-	The `r` varialbe declared in the inner block is not a re-declaration of the one (the return result) declared in the function top block.
+	The `r` variable declared in the inner block is not a re-declaration of the one (the return result) declared in the function top block.
 	It is totally a new declared variable.
 	So the return result is not modified in the inner block.
 

--- a/pages/quizzes/slice-2.html
+++ b/pages/quizzes/slice-2.html
@@ -134,12 +134,12 @@ The other quiz prints <code class="tmd-code-span">0A,1Z,2C,</code>. It is simila
 <ul class="tmd-list">
 <li class="tmd-list-item">
 <div class="tmd-usual">
-The first <code class="tmd-code-span">append</code> call doesn't create a new backing array, so the assignment <code class="tmd-code-span">x[i+1] = "Z"</code> in the first loop has effect on the iniital slice <code class="tmd-code-span">x</code> (and its copy used in the element iteration).
+The first <code class="tmd-code-span">append</code> call doesn't create a new backing array, so the assignment <code class="tmd-code-span">x[i+1] = "Z"</code> in the first loop has effect on the initial slice <code class="tmd-code-span">x</code> (and its copy used in the element iteration).
 </div>
 </li>
 <li class="tmd-list-item">
 <div class="tmd-usual">
-The second <code class="tmd-code-span">append</code> call creates a new backing array, so subsequent <code class="tmd-code-span">x[i+1] = "Z"</code> assignments have no effects on the iniital slice <code class="tmd-code-span">x</code> (and its copy used in the element iteration).
+The second <code class="tmd-code-span">append</code> call creates a new backing array, so subsequent <code class="tmd-code-span">x[i+1] = "Z"</code> assignments have no effects on the initial slice <code class="tmd-code-span">x</code> (and its copy used in the element iteration).
 </div>
 </li>
 </ul>

--- a/pages/quizzes/slice-2.tmd
+++ b/pages/quizzes/slice-2.tmd
@@ -116,11 +116,11 @@ Key points:
 * 
 	The first `append` call doesn't create a new backing array,
 	so the assignment `x[i+1] = "Z"` in the first loop has effect
-	on the iniital slice `x` (and its copy used in the element iteration).
+	on the initial slice `x` (and its copy used in the element iteration).
 * 
 	The second `append` call creates a new backing array,
 	so subsequent `x[i+1] = "Z"` assignments have no effects
-	on the iniital slice `x` (and its copy used in the element iteration).
+	on the initial slice `x` (and its copy used in the element iteration).
 
 
 }


### PR DESCRIPTION
Grammar corrections in `pages/quizzes`, `pages/q-and-a` files.

Updates #241.